### PR TITLE
fix(hra): copy node_modules from builder to fix runtime dependency issue

### DIFF
--- a/packages/hr-agent/Dockerfile
+++ b/packages/hr-agent/Dockerfile
@@ -18,11 +18,8 @@ WORKDIR /app
 
 RUN addgroup -S nodejs && adduser -S nodeuser -G nodejs
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/hr-agent/package.json ./packages/hr-agent/
-
-RUN corepack enable && pnpm install --prod --ignore-scripts
-
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/hr-agent/node_modules ./node_modules
 COPY --from=builder /app/packages/hr-agent/dist ./dist
 
 RUN chown -R nodeuser:nodejs /app


### PR DESCRIPTION
## Summary
- 修复 Docker 镜像运行时找不到 `express` 等依赖的问题
- 将 builder 阶段安装的 `node_modules` 直接复制到运行时镜像，而不是重新安装 `--prod` 依赖

## Root Cause
原 Dockerfile 在运行时阶段使用 `pnpm install --prod` 重新安装依赖，导致开发时依赖（如 TypeScript 相关包）缺失，但构建后的 JS 代码可能需要这些依赖（或其副作用）来正确解析模块路径。

## Solution
- 移除运行时阶段的 `pnpm install --prod` 命令
- 直接从 builder 阶段复制完整的 `node_modules` 到运行时镜像
- 这样可以确保运行时环境与构建时环境一致

## Testing
- 类型检查通过：`pnpm run typecheck` ✅
- 所有测试通过：`pnpm --filter hra test` (39 tests) ✅
- 需要在部署环境重新构建镜像并验证服务正常启动