### PR TITLE
fix(hra): fix Docker deployment issues and module resolution

### DIFF
--- a/packages/hr-agent/Dockerfile
+++ b/packages/hr-agent/Dockerfile
@@ -18,8 +18,11 @@ WORKDIR /app
 
 RUN addgroup -S nodejs && adduser -S nodeuser -G nodejs
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/packages/hr-agent/node_modules ./node_modules
+COPY packages/hr-agent/package.json ./package.json
+COPY pnpm-lock.yaml ./
+
+RUN corepack enable && pnpm install --prod --ignore-scripts --no-frozen-lockfile
+
 COPY --from=builder /app/packages/hr-agent/dist ./dist
 
 RUN chown -R nodeuser:nodejs /app

--- a/packages/hr-agent/src/middleware/autoLoadRoutes.ts
+++ b/packages/hr-agent/src/middleware/autoLoadRoutes.ts
@@ -26,8 +26,12 @@ export default async function autoLoadRoutes(
 
     if (stat.isDirectory()) {
       await processDirectory(router, item, fullPath, basePath);
-    } else if (stat.isFile() && item.endsWith('.ts') && item !== 'index.ts') {
-      await processFile(router, item, fullPath, basePath);
+    } else if (stat.isFile()) {
+      const isTsFile = item.endsWith('.ts') && item !== 'index.ts' && !item.endsWith('.d.ts');
+      const isJsFile = item.endsWith('.js') && item !== 'index.js' && !item.endsWith('.d.js') && !item.endsWith('.map');
+      if (isTsFile || isJsFile) {
+        await processFile(router, item, fullPath, basePath);
+      }
     }
   }
 }
@@ -63,7 +67,14 @@ async function processFile(
   basePath: string
 ): Promise<void> {
   const routeName = basename(item, extname(item));
-  const modulePath = IS_TSX ? fullPath : `${fullPath}.js`;
+  let modulePath: string;
+  if (IS_TSX) {
+    modulePath = fullPath;
+  } else if (item.endsWith('.ts')) {
+    modulePath = `${fullPath.slice(0, -3)}.js`;
+  } else {
+    modulePath = fullPath;
+  }
   const routeModule = await import(modulePath);
   const defaultExport = routeModule.default;
 


### PR DESCRIPTION
## Summary
修复 Docker 部署时的依赖解析和模块加载问题

## Changes

### Dockerfile
- 在运行时镜像中添加 `package.json` 和 `pnpm-lock.yaml` 以支持模块解析
- 使用 `pnpm install --prod` 在运行时阶段安装生产依赖
- 移除了从 builder 阶段复制 node_modules 的方式（pnpm 符号链接在目录结构变化后会失效）

### autoLoadRoutes
- 过滤 `.d.ts`、`.d.js`、`.map` 等非路由文件
- 同时支持 `.ts`（开发环境）和 `.js`（生产环境）文件
- 修复文件扩展名处理逻辑

## Root Cause Analysis

1. **原始问题**: `ERR_MODULE_NOT_FOUND: Cannot find package 'express'`
   - 原因：运行时镜像缺少 `package.json`，Node.js 无法正确解析模块路径
   - pnpm 使用符号链接，从 builder 复制时目录结构不同导致链接失效

2. **后续问题**: `ERR_MODULE_NOT_FOUND: Cannot find module '/app/dist/routes/health.d.ts.js'`
   - 原因：TypeScript 编译生成 `.d.ts` 声明文件，autoLoadRoutes 误认为是路由文件
   - 解决：过滤掉 `.d.ts`、`.d.js`、`.map` 等编译产物

## Testing

- ✅ 类型检查：`pnpm run typecheck` 通过
- ✅ 测试：`pnpm --filter hra test` 通过（39 tests）
- ✅ Docker 镜像构建成功
- ✅ 容器启动成功
- ✅ Health endpoint 响应正常：`{"code":200,"message":"success","data":{"status":"ok"}}`

## Deployment Steps

1. 登录 GitHub Container Registry：`docker login ghcr.io`
2. 构建并推送镜像：
   ```bash
   docker build -t ghcr.io/eeymoo/open-hr-agent-hra:main -f packages/hr-agent/Dockerfile .
   docker push ghcr.io/eeymoo/open-hr-agent-hra:main
   ```
3. Docker Compose 会自动拉取新镜像并重启服务