### PR TITLE
fix(routes): fix file extension parsing for .js files

### DIFF
--- a/packages/hr-agent/src/middleware/autoLoadRoutes.ts
+++ b/packages/hr-agent/src/middleware/autoLoadRoutes.ts
@@ -14,13 +14,13 @@ function buildExpressPath(basePath: string, routePath: string): string {
 }
 
 function parseRouteFileName(fileName: string): { routeName: string; method: string } {
-  const methodMatch = fileName.match(/\.(post|put|delete|patch|get)\.ts$/i);
+  const methodMatch = fileName.match(/\.(post|put|delete|patch|get)\.(ts|js)$/i);
   if (methodMatch) {
     const method = methodMatch[1].toLowerCase();
     const routeName = fileName.slice(0, methodMatch.index);
     return { routeName, method };
   }
-  const routeName = fileName.replace(/\.ts$/, '');
+  const routeName = fileName.replace(/\.ts$/, '').replace(/\.js$/, '');
   return { routeName, method: 'get' };
 }
 


### PR DESCRIPTION
## Problem

Docker images were showing incorrect route registration:
- `GET /health.js` instead of `GET /health`
- `GET /v1/webhooks/issues.post.js` instead of `POST /v1/webhooks/issues`

## Root Cause

The `parseRouteFileName` function regex only matched `.ts` extension:
```javascript
const methodMatch = fileName.match(/\.(post|put|delete|patch|get)\.ts$/i);
```

When compiled to `.js` files, the regex failed to match, leaving the extension in the route name.

## Solution

Updated regex to support both `.ts` and `.js` extensions:
```javascript
const methodMatch = fileName.match(/\.(post|put|delete|patch|get)\.(ts|js)$/i);
```

Also added `.js` extension removal for default GET routes.

## Testing

- All 51 tests passing
- Docker container now shows correct route registration