### PR TITLE
feat(coding-agent): add --hostname 0.0.0.0 to opencode web command

### DIFF
--- a/packages/coding-agent/Dockerfile
+++ b/packages/coding-agent/Dockerfile
@@ -28,9 +28,9 @@ ENV NODE_ENV=production
 
 # 启动命令
 CMD ["/bin/sh", "-c", "if [ -d /home/workspace/repo ]; then \
-        cd /home/workspace/repo && opencode web --port ${PORT}; \
+        cd /home/workspace/repo && opencode web --hostname 0.0.0.0 --port ${PORT}; \
     elif [ -n \"${GITHUB_REPO_URL}\" ]; then \
-        git clone ${GITHUB_REPO_URL} repo && cd /home/workspace/repo && opencode web --port ${PORT}; \
+        git clone ${GITHUB_REPO_URL} repo && cd /home/workspace/repo && opencode web --hostname 0.0.0.0 --port ${PORT}; \
     else \
-        opencode web --port ${PORT}; \
+        opencode web --hostname 0.0.0.0 --port ${PORT}; \
     fi"]


### PR DESCRIPTION
## Summary

- Add `--hostname 0.0.0.0` to all opencode web commands in Dockerfile
- This allows the service to accept connections from any host (useful for Docker deployments)
- Applies to all three scenarios: existing repo, new repo clone, and default workspace