### PR TITLE
fix(docker): resolve Prisma Client ES Module import issue in production

### DIFF
--- a/packages/hr-agent/Dockerfile
+++ b/packages/hr-agent/Dockerfile
@@ -20,9 +20,12 @@ WORKDIR /app
 RUN addgroup -S nodejs && adduser -S nodeuser -G nodejs
 
 COPY packages/hr-agent/package.json ./package.json
+COPY packages/hr-agent/prisma ./prisma
 COPY pnpm-lock.yaml ./
 
-RUN corepack enable && pnpm install --prod --ignore-scripts --no-frozen-lockfile
+RUN corepack enable && pnpm install --prod --no-frozen-lockfile --ignore-scripts
+
+RUN pnpm add -D prisma@5.22.0 --ignore-scripts && pnpm exec prisma generate
 
 COPY --from=builder /app/packages/hr-agent/dist ./dist
 


### PR DESCRIPTION
- Copy prisma schema files to production stage
- Install prisma as devDependency in production stage
- Generate Prisma Client after dependencies installation
- Use --ignore-scripts to skip husky setup in Docker environment
- Ensures Prisma Client is properly generated and available at runtime

This fixes the 'Named export PrismaClient not found' error that occurred when starting the containerized application.