### PR TITLE
fix(web): resolve nginx envsubst syntax error by handling default value in shell

### DIFF
--- a/packages/hr-agent-web/Dockerfile
+++ b/packages/hr-agent-web/Dockerfile
@@ -16,4 +16,4 @@ COPY nginx.conf /etc/nginx/templates/nginx.conf.template
 
 EXPOSE 80
 
-CMD ["sh", "-c", "envsubst '$$HRA_URL' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]
+CMD ["sh", "-c", "export HRA_URL=\"${HRA_URL:-http://open-hr-agent:3000}\" && envsubst '\$HRA_URL' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]

--- a/packages/hr-agent-web/nginx.conf
+++ b/packages/hr-agent-web/nginx.conf
@@ -41,7 +41,7 @@ http {
     }
 
     location /api {
-      proxy_pass ${HRA_URL:-http://open-hr-agent:3000};
+      proxy_pass ${HRA_URL};
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
• Fixed nginx container startup failure caused by envsubst variable syntax error
• Moved default value handling from nginx config to shell command for proper variable substitution

## Problem
The nginx container was failing to start with error:
```
nginx: [emerg] the closing bracket in "HRA_URL" variable is missing
```

This occurred because nginx.conf used bash-style default syntax `${HRA_URL:-default}` which envsubst does not support, causing the string to be left unchanged and breaking nginx parsing.

## Solution
- Simplified nginx.conf to use plain variable `${HRA_URL}` without default value
- Moved default value handling to Dockerfile CMD using shell syntax: `export HRA_URL="${HRA_URL:-http://open-hr-agent:3000}"` before running envsubst

## Changes
- **packages/hr-agent-web/nginx.conf**: Changed `proxy_pass ${HRA_URL:-http://open-hr-agent:3000}` to `proxy_pass ${HRA_URL}`
- **packages/hr-agent-web/Dockerfile**: Updated CMD to set default value in shell before envsubst execution

This ensures envsubst receives a clean variable to replace without parsing bash syntax.