### PR TITLE
fix(web): fix nginx envsubst shell syntax error

### DIFF
--- a/packages/hr-agent-web/Dockerfile
+++ b/packages/hr-agent-web/Dockerfile
@@ -16,4 +16,4 @@ COPY nginx.conf /etc/nginx/templates/nginx.conf.template
 
 EXPOSE 80
 
-CMD ["sh", "-c", "export HRA_URL=\"${HRA_URL:-http://open-hr-agent:3000}\" && envsubst '\$HRA_URL' < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'"]
+CMD /bin/sh -c 'export HRA_URL=${HRA_URL:-http://open-hr-agent:3000} && envsubst < /etc/nginx/templates/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g "daemon off;"'


### PR DESCRIPTION
## Summary
- 修复了 hr-agent-web 容器启动时的 shell 语法错误
- 修复了 `/bin/sh: [sh,: not found` 错误
- 优化了 CMD 命令的 shell 转义处理

## Changes
- 修改 Dockerfile CMD 指令：从 JSON 数组格式改为 shell 字符串格式
- 移除不必要的引号转义，使命令在 Alpine Linux 上正确解析
- 简化 envsubst 命令参数

## Issue
Fixes Docker 容器启动失败的问题，该问题导致容器不断重启并报错：
```
/bin/sh: [sh,: not found
```

## Testing
- 修改后的命令语法正确，可以在 Alpine Linux 上正常执行
- envsubst 可以正确替换环境变量