### PR TITLE
chore: add check before commit in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,6 @@
+pnpm run check
+if [ $? -ne 0 ]; then
+  echo "❌ Check failed. Please fix typecheck and lint errors before committing."
+  exit 1
+fi
 npx lint-staged


### PR DESCRIPTION
## Summary
• 增强 pre-commit 钩子，在提交前强制执行 `pnpm run check`
• 只有 typecheck 和 lint 通过后才允许提交代码

## Changes
- 修改 `.husky/pre-commit` 脚本
- 添加 `pnpm run check` 验证步骤
- 如果检查失败则阻止提交并显示错误提示

## Testing
- 测试了提交被阻止的场景（依赖未安装、typecheck 失败）
- 验证修复后提交成功