### PR TITLE
fix(hra): fix Docker deployment issues - duplicate CA and Docker Secrets

### DIFF
--- a/packages/hr-agent/scripts/docker-entrypoint.sh
+++ b/packages/hr-agent/scripts/docker-entrypoint.sh
@@ -1,6 +1,23 @@
 #!/bin/sh
 set -e
 
+# Handle Docker Secrets - read *_FILE variables and export them
+if [ -n "$DATABASE_URL_FILE" ]; then
+  export DATABASE_URL=$(cat $DATABASE_URL_FILE)
+fi
+
+if [ -n "$GITHUB_WEBHOOK_SECRET_FILE" ]; then
+  export GITHUB_WEBHOOK_SECRET=$(cat $GITHUB_WEBHOOK_SECRET_FILE)
+fi
+
+if [ -n "$DOCKER_CA_SECRET_FILE" ]; then
+  export DOCKER_CA_SECRET=$(cat $DOCKER_CA_SECRET_FILE)
+fi
+
+if [ -n "$CSP_DOMAIN_FILE" ]; then
+  export CSP_DOMAIN=$(cat $CSP_DOMAIN_FILE)
+fi
+
 # Wait for database to be ready
 echo "Waiting for database connection..."
 while ! npx prisma db push --skip-generate 2>/dev/null; do


### PR DESCRIPTION
## Summary
- Fix duplicate CA creation when webhook triggers multiple times
- Handle Docker Secrets in docker-entrypoint.sh for proper environment variable resolution

## Changes

### 1. Prevent Duplicate CA Creation
- Added duplicate CA record check before creating new CA
- Handle unique constraint violation (P2002) gracefully
- Destroy existing CA with same name before creating new one
- Cleanup old error CA to prevent resource exhaustion

### 2. Handle Docker Secrets
- Modified `docker-entrypoint.sh` to read `*_FILE` environment variables
- Export `DATABASE_URL`, `GITHUB_WEBHOOK_SECRET`, `DOCKER_CA_SECRET`, and `CSP_DOMAIN`
- Required for `docker-compose` deployment with Docker Secrets
- Fixes issue where environment variables were empty, causing database connection failures

## Problem Fixed
Previously, when using `docker-compose` with Docker Secrets:
- Environment variables like `DATABASE_URL_FILE` were set but not read
- Resulted in empty `DATABASE_URL`, causing Prisma connection errors
- Tasks would remain queued without execution due to database unavailability

## Testing
- Verified local Docker deployment with docker-compose
- Confirmed database connection and task execution work correctly
- Tested webhook-triggered task creation and execution

## Related Issues
- Fixes Docker deployment issues
- Resolves task queue not processing in containerized environment