### PR TITLE
fix(hra): resolve Docker container name inconsistency

### DIFF
--- a/packages/hr-agent/src/tasks/destroyCaTask.ts
+++ b/packages/hr-agent/src/tasks/destroyCaTask.ts
@@ -17,8 +17,8 @@ export class DestroyCaTask extends BaseTask {
     try {
       const container = await getContainerByName(caName);
 
-      if (container?.id) {
-        await deleteContainer(container.id);
+      if (container?.name) {
+        await deleteContainer(container.name);
         await this.logger.info(context.taskId, this.name, 'CA 容器销毁成功', { caName });
       } else {
         await this.logger.warn(context.taskId, this.name, 'CA 容器不存在，跳过销毁', { caName });

--- a/packages/hr-agent/src/utils/docker/createContainer.ts
+++ b/packages/hr-agent/src/utils/docker/createContainer.ts
@@ -30,6 +30,7 @@ export async function createContainer(name: string, repoUrl?: string): Promise<s
 
   try {
     console.log('Creating Docker container...');
+    const containerName = `ca-${name}`;
     const envVars = [
       `PORT=${DOCKER_CONFIG.PORT}`,
       `OPENCODE_SERVER_PASSWORD=${DOCKER_CONFIG.SECRET}`
@@ -39,7 +40,7 @@ export async function createContainer(name: string, repoUrl?: string): Promise<s
     }
 
     const container = await docker.createContainer({
-      name,
+      name: containerName,
       Image: DOCKER_CONFIG.IMAGE,
       Env: envVars,
       HostConfig: {

--- a/packages/hr-agent/src/utils/docker/deleteContainer.ts
+++ b/packages/hr-agent/src/utils/docker/deleteContainer.ts
@@ -4,12 +4,12 @@ const docker = new Docker();
 
 /**
  * 删除 Docker 容器
- * @param name - 容器名称（不含 'ca-' 前缀）
+ * @param id - 容器 ID 或容器名称
  * @param force - 是否强制删除，默认为 false
  * @throws 删除失败时抛出错误
  */
-export async function deleteContainer(name: string, force: boolean = false): Promise<void> {
-  const container = docker.getContainer(`ca-${name}`);
+export async function deleteContainer(id: string, force: boolean = false): Promise<void> {
+  const container = docker.getContainer(id);
 
   try {
     await container.remove({ force, v: true });


### PR DESCRIPTION
## Summary
This PR resolves the Docker container name inconsistency issue across all Docker operations.

## Changes
- **createContainer.ts**: Updated to use `ca-${name}` format for consistency
- **deleteContainer.ts**: Modified to accept container ID instead of name
- **destroyCaTask.ts**: Updated to pass container name instead of ID

## Problem
The Docker container naming was inconsistent:
- `createContainer()` created containers with the original name (e.g., `hra_123`)
- `getContainerByName()` queried with `ca-` prefix (e.g., `ca-hra_123`)
- `deleteContainer()` also used `ca-` prefix
- `listContainers()` filtered for `/ca-` prefix

This caused:
- CA containers could not be found after creation
- Container deletion failed
- Resource leaks

## Solution
Unified all Docker operations to use `ca-${name}` format and updated function signatures accordingly.

Fixes #1 in ISSUES.md