### PR TITLE
fix(web): extract hardcoded CA URL to constants

### DIFF
--- a/packages/hr-agent-web/src/components/TaskCard/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskCard/index.tsx
@@ -14,6 +14,7 @@ import {
   type Task
 } from '../../types/task';
 import { formatTimestamp, formatPriority } from '../../utils/formatters';
+import { CA_BASE_URL } from '../../utils/constants';
 import './index.css';
 
 const PROGRESS_QUEUED = 0;
@@ -126,7 +127,7 @@ function TaskCardContent({
 export function TaskCard({ task, onClick, onEdit, onDelete, showActions = true }: TaskCardProps) {
   const handleCAUrlClick = () => {
     if (task.codingAgent) {
-      window.open('http://localhost:4096', '_blank');
+      window.open(CA_BASE_URL, '_blank');
     }
   };
 

--- a/packages/hr-agent-web/src/components/TaskModal/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskModal/index.tsx
@@ -13,6 +13,7 @@ import {
   type Task
 } from '../../types/task';
 import { formatTimestamp, formatDuration, TIMESTAMP_NEGATIVE_TWO } from '../../utils/formatters';
+import { CA_BASE_URL } from '../../utils/constants';
 
 const { Paragraph } = Typography;
 
@@ -29,7 +30,7 @@ export function TaskModal({ open, task, onClose }: TaskModalProps) {
 
   const handleCAUrlClick = () => {
     if (task.codingAgent) {
-      window.open('http://localhost:4096', '_blank');
+      window.open(CA_BASE_URL, '_blank');
     }
   };
 

--- a/packages/hr-agent-web/src/utils/constants.ts
+++ b/packages/hr-agent-web/src/utils/constants.ts
@@ -1,4 +1,5 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api';
+export const CA_BASE_URL = import.meta.env.VITE_CA_BASE_URL || 'http://localhost:4096';
 export const POLLING_INTERVAL = Number(import.meta.env.VITE_POLLING_INTERVAL) || 60000;
 
 export const ROUTES = {


### PR DESCRIPTION
## Summary
• 将硬编码的 CA URL 提取到 constants.ts 常量文件中
• 支持通过环境变量 VITE_CA_BASE_URL 配置 CA 基础 URL

## Changes
- 在 utils/constants.ts 中添加 CA_BASE_URL 常量，默认值为 'http://localhost:4096'
- 修改 TaskModal 组件使用 CA_BASE_URL 常量替代硬编码 URL
- 修改 TaskCard 组件使用 CA_BASE_URL 常量替代硬编码 URL

## Related Issue
解决 REFACTORING_ISSUES.md 中的问题 #1