### PR TITLE
fix(hra): filter test files in autoLoadRoutes to prevent production errors

### DIFF
--- a/packages/hr-agent/src/middleware/autoLoadRoutes.ts
+++ b/packages/hr-agent/src/middleware/autoLoadRoutes.ts
@@ -62,6 +62,10 @@ function isValidRouteFile(item: string): boolean {
     return false;
   }
 
+  if (item.endsWith('.test.ts') || item.endsWith('.test.js') || item.endsWith('.spec.ts') || item.endsWith('.spec.js')) {
+    return false;
+  }
+
   return item.endsWith('.ts') || item.endsWith('.js');
 }
 


### PR DESCRIPTION
## Summary
- Filter test files (*.test.ts, *.test.js, *.spec.ts, *.spec.js) in `isValidRouteFile` function
- Prevents Vitest mocker errors when test files are auto-loaded in production environment
- Resolves Docker deployment crash caused by test file imports

## Problem
The `autoLoadRoutes` middleware was loading all TypeScript files from the routes directory, including test files. In production (Docker), test files that use Vitest's `vi.mock()` would cause runtime errors because Vitest mocker is not initialized outside the test environment, leading to deployment crashes.

## Solution
Updated `isValidRouteFile` function to filter out test files before loading them as routes.

## Testing
- Manual testing with Docker deployment confirmed containers start successfully
- All API routes are properly registered
- Health check endpoint responds correctly