### PR TITLE
fix: 现在的 api 在 SECRET 错误情况下也可以正常访问页面，需要限制 SECRET 错误是提示 'SECRET 错误'

### DIFF
--- a/packages/hr-agent-web/src/api/client.ts
+++ b/packages/hr-agent-web/src/api/client.ts
@@ -28,6 +28,8 @@ apiClient.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       sessionStorage.removeItem('hra_secret');
+      const errorMessage = error.response?.data?.message || '登录失败，请检查 SECRET 是否正确';
+      sessionStorage.setItem('hra_last_error', errorMessage);
       window.location.href = '/login';
     }
     return Promise.reject(error);

--- a/packages/hr-agent-web/src/pages/Login/index.tsx
+++ b/packages/hr-agent-web/src/pages/Login/index.tsx
@@ -21,6 +21,12 @@ export function Login() {
     if (isAuthenticated) {
       navigate('/orchestration', { replace: true });
     }
+
+    const lastError = sessionStorage.getItem('hra_last_error');
+    if (lastError) {
+      message.error(lastError);
+      sessionStorage.removeItem('hra_last_error');
+    }
   }, [isAuthenticated, navigate]);
 
   const handleSubmit = async (values: LoginForm) => {

--- a/packages/hr-agent/src/index.ts
+++ b/packages/hr-agent/src/index.ts
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 import toonMiddleware from './middleware/responseFormat/toonMiddleware.js';
 import autoLoadRoutes from './middleware/autoLoadRoutes.js';
 import caProxyMiddleware from './middleware/caProxy.js';
+import validateSecretMiddleware from './middleware/validateSecret.js';
 import { EventBus } from './services/eventBus.js';
 import { TaskLogger } from './utils/taskLogger.js';
 import { TaskRegistry } from './tasks/taskRegistry.js';
@@ -26,7 +27,17 @@ const ROUTES_DIR = join(__dirname, 'routes');
 app.use(express.json());
 app.use(toonMiddleware);
 
-await autoLoadRoutes(app, ROUTES_DIR);
+const v1Router = express.Router();
+v1Router.use(validateSecretMiddleware);
+
+await autoLoadRoutes(v1Router, join(ROUTES_DIR, 'v1'));
+
+app.use('/v1', v1Router);
+
+const nonV1Router = express.Router();
+await autoLoadRoutes(nonV1Router, ROUTES_DIR);
+
+app.use('/', nonV1Router);
 
 app.use(caProxyMiddleware);
 

--- a/packages/hr-agent/src/middleware/validateSecret.ts
+++ b/packages/hr-agent/src/middleware/validateSecret.ts
@@ -1,0 +1,22 @@
+import type { Request, Response, NextFunction } from 'express';
+import Result from '../utils/Result.js';
+
+const HTTP = {
+  UNAUTHORIZED: 401
+};
+
+const SECRET_HEADER = 'x-secret';
+const EXPECTED_SECRET = process.env.HRA_SECRET ?? 'hr-agent-secret';
+
+function validateSecretMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const clientSecret = req.headers[SECRET_HEADER] as string;
+
+  if (!clientSecret || clientSecret !== EXPECTED_SECRET) {
+    res.json(new Result().error(HTTP.UNAUTHORIZED, 'SECRET 错误'));
+    return;
+  }
+
+  next();
+}
+
+export default validateSecretMiddleware;


### PR DESCRIPTION
## Summary

- 为 `/v1/*` 路由添加 SECRET 验证中间件，防止使用错误的 SECRET 访问 API
- 前端显示 "SECRET 错误" 提示信息，引导用户重新登录

## Changes

### Backend (hr-agent)
- 新增 `validateSecret` 中间件，验证请求头的 `X-Secret` 是否与 `HRA_SECRET` 匹配
- 将验证中间件应用到所有 `/v1/*` 路由
- 保持 `/health` 和 `/ca/*` 路由无需 SECRET 验证

### Frontend (hr-agent-web)
- 更新 API 客户端拦截器，在 401 错误时保存错误消息
- 修改登录页面，显示保存的错误消息（"SECRET 错误"）

## Testing

- 类型检查通过
- ESLint 检查通过
- 测试通过

Closes #116