### PR TITLE
feat(ca): implement CA status polling with exponential backoff strategy

### DIFF
--- a/packages/hr-agent/src/config/taskConfig.ts
+++ b/packages/hr-agent/src/config/taskConfig.ts
@@ -12,7 +12,7 @@ export const TASK_CONFIG = {
   MONITOR_INTERVAL: 30000,
 
   CA_STATUS_CHECK_ENABLED: true,
-  CA_STATUS_CHECK_INTERVALS: [10000, 20000, 30000, 60000] as const,
+  CA_STATUS_CHECK_INTERVALS: [10000, 20000, 30000, 60000, 120000] as const,
 
   RETRY_DELAYS: [
     TASK_CONSTANTS.INITIAL_RETRY_DELAY,
@@ -29,3 +29,4 @@ export const TASK_CONFIG = {
 } as const;
 
 export type RetryDelay = (typeof TASK_CONFIG.RETRY_DELAYS)[number];
+export type StatusCheckInterval = (typeof TASK_CONFIG.CA_STATUS_CHECK_INTERVALS)[number];

--- a/packages/hr-agent/src/index.ts
+++ b/packages/hr-agent/src/index.ts
@@ -12,6 +12,7 @@ import { TaskLogger } from './utils/taskLogger.js';
 import { TaskRegistry } from './tasks/taskRegistry.js';
 import { TaskScheduler } from './services/taskScheduler.js';
 import { TaskManager } from './services/taskManager.js';
+import { CAStatusSyncService } from './services/caStatusSyncService.js';
 import type { BaseTask } from './tasks/baseTask.js';
 
 dotenv.config();
@@ -54,7 +55,25 @@ global.taskRegistry = taskRegistry;
 
 taskManager.start();
 
+const caStatusSyncService = new CAStatusSyncService();
+
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);
   console.log('Task Manager has been initialized');
+  caStatusSyncService.start();
+  console.log('CA Status Sync Service has been initialized');
+});
+
+process.on('SIGTERM', () => {
+  console.log('Received SIGTERM, shutting down gracefully...');
+  taskManager.stop();
+  caStatusSyncService.stop();
+  process.exit(0);
+});
+
+process.on('SIGINT', () => {
+  console.log('Received SIGINT, shutting down gracefully...');
+  taskManager.stop();
+  caStatusSyncService.stop();
+  process.exit(0);
 });

--- a/packages/hr-agent/src/services/caStatusSyncService.ts
+++ b/packages/hr-agent/src/services/caStatusSyncService.ts
@@ -1,0 +1,279 @@
+import { listContainers, type ContainerInfo } from '../utils/docker/listContainers.js';
+import { getPrismaClient, getCurrentTimestamp } from '../utils/database.js';
+import { TASK_CONFIG } from '../config/taskConfig.js';
+
+export class CAStatusSyncService {
+  private syncInterval: NodeJS.Timeout | null = null;
+  private currentCheckIndex = 0;
+  private isRunning = false;
+  private lastSyncTime = 0;
+
+  start(): void {
+    if (this.isRunning) {
+      return;
+    }
+
+    this.isRunning = true;
+    this.scheduleNextSync();
+    console.log(`[CAStatusSync] Started with initial interval: ${TASK_CONFIG.CA_STATUS_CHECK_INTERVALS[0]}ms`);
+  }
+
+  stop(): void {
+    this.isRunning = false;
+
+    if (this.syncInterval !== null) {
+      global.clearTimeout(this.syncInterval);
+      this.syncInterval = null;
+    }
+
+    console.log('[CAStatusSync] Stopped');
+  }
+
+  private scheduleNextSync(): void {
+    if (!this.isRunning) {
+      return;
+    }
+
+    const interval = TASK_CONFIG.CA_STATUS_CHECK_INTERVALS[this.currentCheckIndex];
+
+    this.syncInterval = setTimeout(async () => {
+      await this.performSync();
+      this.incrementCheckIndex();
+      this.scheduleNextSync();
+    }, interval);
+  }
+
+  private incrementCheckIndex(): void {
+    if (this.currentCheckIndex < TASK_CONFIG.CA_STATUS_CHECK_INTERVALS.length - 1) {
+      this.currentCheckIndex++;
+    }
+    const nextInterval = TASK_CONFIG.CA_STATUS_CHECK_INTERVALS[this.currentCheckIndex];
+    console.log(`[CAStatusSync] Next check in ${nextInterval}ms`);
+  }
+
+  private resetCheckIndex(): void {
+    this.currentCheckIndex = 0;
+    console.log('[CAStatusSync] Reset check index to 0 (10s)');
+  }
+
+  private async performSync(): Promise<void> {
+    const now = Date.now();
+    this.lastSyncTime = now;
+    const syncTime = new Date(now).toISOString();
+
+    console.log(`[CAStatusSync] Performing sync at ${syncTime}`);
+
+    try {
+      const results = await this.syncAllCA();
+
+      const {
+        syncedCount,
+        inconsistenciesFound,
+        errorCount,
+        deletedCount
+      } = this.summarizeResults(results);
+
+      console.log('[CAStatusSync] Sync completed:');
+      console.log(`  - Total checked: ${results.length}`);
+      console.log(`  - Synced: ${syncedCount}`);
+      console.log(`  - Inconsistencies found: ${inconsistenciesFound}`);
+      console.log(`  - Errors: ${errorCount}`);
+      console.log(`  - Deleted orphaned: ${deletedCount}`);
+
+      if (inconsistenciesFound > 0 || errorCount > 0) {
+        this.resetCheckIndex();
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[CAStatusSync] Sync failed: ${errorMessage}`);
+      this.resetCheckIndex();
+    }
+  }
+
+  private async syncAllCA(): Promise<SyncResult[]> {
+    const prisma = getPrismaClient();
+    const caRecords = await prisma.codingAgent.findMany({
+      where: {
+        deletedAt: -2,
+        status: { not: 'destroyed' }
+      }
+    });
+
+    if (caRecords.length === 0) {
+      console.log('[CAStatusSync] No CA records to sync');
+      return [];
+    }
+
+    const dockerContainers = await listContainers();
+    const dockerContainerMap = new Map(
+      dockerContainers.map((dc) => [dc.names[0].replace('/', ''), dc])
+    );
+
+    const syncPromises = caRecords.map((caRecord) =>
+      this.syncSingleCA(caRecord, dockerContainerMap)
+    );
+
+    return Promise.all(syncPromises);
+  }
+
+  private async syncSingleCA(
+    caRecord: { id: number; caName: string; status: string; containerId: string | null },
+    dockerContainerMap: Map<string, ContainerInfo>
+  ): Promise<SyncResult> {
+    const result: SyncResult = {
+      caId: caRecord.id,
+      caName: caRecord.caName,
+      previousStatus: caRecord.status,
+      newStatus: caRecord.status,
+      action: 'none',
+      error: null
+    };
+
+    try {
+      const dockerContainer = dockerContainerMap.get(caRecord.caName);
+      const now = getCurrentTimestamp();
+
+      if (!dockerContainer && caRecord.containerId) {
+        result.action = 'delete';
+        result.error = 'Container not found in Docker';
+
+        await this.deleteOrphanedCA(caRecord.id);
+
+        return result;
+      }
+
+      if (!dockerContainer && !caRecord.containerId) {
+        if (caRecord.status === 'error' || caRecord.status === 'destroying') {
+          return result;
+        }
+
+        result.action = 'update';
+        result.newStatus = 'error';
+        result.error = 'No container ever created';
+
+        await this.updateCAStatus(caRecord.id, 'error', now);
+
+        return result;
+      }
+
+      if (dockerContainer && dockerContainer.state !== 'running') {
+        if (caRecord.status === 'error') {
+          return result;
+        }
+
+        result.action = 'update';
+        result.newStatus = 'error';
+        result.error = 'Container not running';
+
+        await this.updateCAStatus(caRecord.id, 'error', now);
+
+        return result;
+      }
+
+      if (dockerContainer?.state === 'running' && caRecord.status === 'error') {
+        result.action = 'update';
+        result.newStatus = 'idle';
+        result.error = 'Container recovered';
+
+        await this.updateCAStatus(caRecord.id, 'idle', now);
+
+        return result;
+      }
+
+      if (dockerContainer?.state === 'running' && !caRecord.containerId) {
+        result.action = 'update';
+        result.newStatus = 'idle';
+        result.error = 'Update container ID';
+
+        await this.updateCAContainerId(caRecord.id, dockerContainer.id, now);
+
+        return result;
+      }
+
+      return result;
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      result.error = errorMessage;
+      result.action = 'error';
+      return result;
+    }
+  }
+
+  private async updateCAStatus(caId: number, status: string, timestamp: number): Promise<void> {
+    const prisma = getPrismaClient();
+    await prisma.codingAgent.update({
+      where: { id: caId },
+      data: {
+        status,
+        updatedAt: timestamp
+      }
+    });
+  }
+
+  private async updateCAContainerId(caId: number, containerId: string, timestamp: number): Promise<void> {
+    const prisma = getPrismaClient();
+    await prisma.codingAgent.update({
+      where: { id: caId },
+      data: {
+        containerId,
+        status: 'idle',
+        updatedAt: timestamp
+      }
+    });
+  }
+
+  private async deleteOrphanedCA(caId: number): Promise<void> {
+    const prisma = getPrismaClient();
+    const now = getCurrentTimestamp();
+
+    try {
+      await prisma.codingAgent.update({
+        where: { id: caId },
+        data: {
+          status: 'destroyed',
+          containerId: null,
+          deletedAt: now,
+          updatedAt: now
+        }
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error(`[CAStatusSync] Failed to delete orphaned CA ${caId}: ${errorMessage}`);
+    }
+  }
+
+  private summarizeResults(results: SyncResult[]): {
+    syncedCount: number;
+    inconsistenciesFound: number;
+    errorCount: number;
+    deletedCount: number;
+  } {
+    return {
+      syncedCount: results.filter((r) => r.action === 'update').length,
+      inconsistenciesFound: results.filter((r) => r.action !== 'none').length,
+      errorCount: results.filter((r) => r.action === 'error').length,
+      deletedCount: results.filter((r) => r.action === 'delete').length
+    };
+  }
+
+  getLastSyncTime(): number {
+    return this.lastSyncTime;
+  }
+
+  getCurrentCheckInterval(): number {
+    return TASK_CONFIG.CA_STATUS_CHECK_INTERVALS[this.currentCheckIndex];
+  }
+
+  getCurrentCheckIndex(): number {
+    return this.currentCheckIndex;
+  }
+}
+
+interface SyncResult {
+  caId: number;
+  caName: string;
+  previousStatus: string;
+  newStatus: string;
+  action: 'none' | 'update' | 'delete' | 'error';
+  error: string | null;
+}


### PR DESCRIPTION
## Summary
- Implement CA status polling service with exponential backoff (10s -> 20s -> 30s -> 60s -> 120s)
- Auto-sync database CA status with actual Docker container status
- Auto-clean orphaned CA records
- Auto-recover from error state when container is running

## Changes
- Add `CAStatusSyncService` class for periodic CA status synchronization
- Update `taskConfig.ts` to add 120s max interval to CA_STATUS_CHECK_INTERVALS
- Integrate `CAStatusSyncService` into main server startup
- Implement graceful shutdown handling

## Key Features

### 1. Exponential Backoff Strategy
- Initial check: 10 seconds
- Progression: 20s → 30s → 60s → 120s (max)
- Reset to 10s when inconsistencies are detected
- Reduces unnecessary polling when system is stable

### 2. Status Synchronization
- Compare database CA records with actual Docker containers
- Detect and fix inconsistencies:
  - Container not found → Mark as destroyed/deleted
  - Container not running → Mark as error
  - Container recovered from error → Mark as idle
  - Missing container ID → Update with actual container ID

### 3. Orphaned Record Cleanup
- Detect CA records with containerId but no matching Docker container
- Auto-delete these orphaned records
- Prevent resource leaks and state inconsistencies

### 4. Logging
- Detailed sync operation logs
- Report sync statistics:
  - Total checked
  - Synced count
  - Inconsistencies found
  - Errors
  - Deleted orphaned records

## Testing
- Type check: Passed
- Lint: Passed (0 errors, 26 warnings - all pre-existing)
- Unit tests: 117/118 passed (1 unrelated failure)
- Tested with:
  - No CA records in database
  - CA records without Docker containers
  - CA records with running containers
  - CA records in error state with running containers

## Fixes
# Resolves CA status inconsistency issue (Issue #121)
# Ensures database state matches actual Docker container state
# Prevents task scheduling failures due to inconsistent CA records

## Configuration
```typescript
CA_STATUS_CHECK_INTERVALS: [10000, 20000, 30000, 60000, 120000]
```