### PR TITLE
feat(web): 统一列表页面的 header 组件并修复表格超宽问题

### DIFF
--- a/packages/hr-agent-web/src/components/ListHeader/index.css
+++ b/packages/hr-agent-web/src/components/ListHeader/index.css
@@ -1,0 +1,54 @@
+.list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+  padding: 20px 24px;
+  background: var(--bg-glass);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-glass);
+  border-radius: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.list-header::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--purple-main), var(--accent-cyan), var(--purple-main));
+}
+
+.list-header::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: linear-gradient(135deg, rgba(139, 92, 246, 0.05), transparent);
+  pointer-events: none;
+}
+
+.header-left {
+  position: relative;
+  z-index: 1;
+}
+
+.header-left h2 {
+  margin: 0 0 4px 0;
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.3px;
+}
+
+.list-count {
+  font-size: 14px;
+  color: var(--text-secondary);
+  font-weight: 500;
+}

--- a/packages/hr-agent-web/src/components/ListHeader/index.tsx
+++ b/packages/hr-agent-web/src/components/ListHeader/index.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react';
+import { Button, Input, Space } from 'antd';
+import type { SearchProps } from 'antd/es/input/Search';
+
+import './index.css';
+
+interface ListHeaderProps {
+  title: string;
+  count: number;
+  countLabel: string;
+  searchPlaceholder: string;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onSearch: SearchProps['onSearch'];
+  actionButton?: {
+    icon?: ReactNode;
+    text: string;
+    onClick: () => void;
+  };
+}
+
+export function ListHeader({
+  title,
+  count,
+  countLabel,
+  searchPlaceholder,
+  searchValue,
+  onSearchChange,
+  onSearch,
+  actionButton
+}: ListHeaderProps) {
+  return (
+    <div className="list-header">
+      <div className="header-left">
+        <h2>{title}</h2>
+        <span className="list-count">
+          共 {count} {countLabel}
+        </span>
+      </div>
+      <Space>
+        <Input.Search
+          placeholder={searchPlaceholder}
+          allowClear
+          style={{ width: 300 }}
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
+          onSearch={onSearch}
+        />
+        {actionButton && (
+          <Button type="primary" icon={actionButton.icon} onClick={actionButton.onClick}>
+            {actionButton.text}
+          </Button>
+        )}
+      </Space>
+    </div>
+  );
+}

--- a/packages/hr-agent-web/src/pages/CAs/index.tsx
+++ b/packages/hr-agent-web/src/pages/CAs/index.tsx
@@ -34,6 +34,7 @@ import {
   CA_STATUS_LABELS,
   CA_STATUS_COLORS
 } from '../../types/ca';
+import { ListHeader } from '../../components/ListHeader';
 
 import './index.css';
 
@@ -262,24 +263,20 @@ function CAsListContent({
 
   return (
     <div className="cas-list">
-      <div className="cas-header">
-        <div className="header-left">
-          <h2>Coding Agents 列表</h2>
-          <span className="ca-count">共 {pagination?.total || 0} 个 Coding Agent</span>
-        </div>
-        <Space>
-          <Input.Search
-            placeholder="搜索 ID 或名称"
-            allowClear
-            style={{ width: 300 }}
-            onSearch={handleSearch}
-            onChange={(e) => setSearchText(e.target.value)}
-          />
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-            添加 CA
-          </Button>
-        </Space>
-      </div>
+      <ListHeader
+        title="Coding Agents 列表"
+        count={pagination?.total || 0}
+        countLabel="个 Coding Agent"
+        searchPlaceholder="搜索 ID 或名称"
+        searchValue={searchText}
+        onSearchChange={setSearchText}
+        onSearch={handleSearch}
+        actionButton={{
+          icon: <PlusOutlined />,
+          text: '添加 CA',
+          onClick: () => setModalOpen(true)
+        }}
+      />
 
       <Card className="cas-card">
         {filteredCAs.length === 0 ? (
@@ -289,6 +286,7 @@ function CAsListContent({
             dataSource={filteredCAs}
             columns={columns}
             rowKey="id"
+            scroll={{ x: 'max-content' }}
             pagination={{
               current: page,
               pageSize,

--- a/packages/hr-agent-web/src/pages/Issues/index.tsx
+++ b/packages/hr-agent-web/src/pages/Issues/index.tsx
@@ -5,6 +5,7 @@ import { useIssues, useCreateIssue } from '../../hooks/useIssues';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import type { Issue } from '../../types/issue';
 import { formatDate, getIssueStatusTag } from '../../utils/formatters';
+import { ListHeader } from '../../components/ListHeader';
 
 import './index.css';
 
@@ -145,24 +146,20 @@ function IssuesListContent({
 
   return (
     <div className="issues-list">
-      <div className="issues-header">
-        <div className="header-left">
-          <h2>Issues 列表</h2>
-          <span className="issue-count">共 {pagination?.total || 0} 个 Issue</span>
-        </div>
-        <Space>
-          <Input.Search
-            placeholder="搜索 Issue ID 或标题"
-            allowClear
-            style={{ width: 300 }}
-            onSearch={handleSearch}
-            onChange={(e) => setSearchText(e.target.value)}
-          />
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-            添加 Issue
-          </Button>
-        </Space>
-      </div>
+      <ListHeader
+        title="Issues 列表"
+        count={pagination?.total || 0}
+        countLabel="个 Issue"
+        searchPlaceholder="搜索 Issue ID 或标题"
+        searchValue={searchText}
+        onSearchChange={setSearchText}
+        onSearch={handleSearch}
+        actionButton={{
+          icon: <PlusOutlined />,
+          text: '添加 Issue',
+          onClick: () => setModalOpen(true)
+        }}
+      />
 
       <Card className="issues-card">
         {filteredIssues.length === 0 ? (
@@ -172,6 +169,7 @@ function IssuesListContent({
             dataSource={filteredIssues}
             columns={columns}
             rowKey="id"
+            scroll={{ x: 'max-content' }}
             pagination={{
               current: page,
               pageSize,

--- a/packages/hr-agent-web/src/pages/PRs/index.tsx
+++ b/packages/hr-agent-web/src/pages/PRs/index.tsx
@@ -5,6 +5,7 @@ import { usePRs, useCreatePR } from '../../hooks/usePRs';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import type { PullRequest } from '../../types/pr';
 import { formatDate, getPRStatusTag } from '../../utils/formatters';
+import { ListHeader } from '../../components/ListHeader';
 
 import './index.css';
 
@@ -145,24 +146,20 @@ function PRsListContent({
 
   return (
     <div className="prs-list">
-      <div className="prs-header">
-        <div className="header-left">
-          <h2>Pull Requests 列表</h2>
-          <span className="pr-count">共 {pagination?.total || 0} 个 PR</span>
-        </div>
-        <Space>
-          <Input.Search
-            placeholder="搜索 PR ID 或标题"
-            allowClear
-            style={{ width: 300 }}
-            onSearch={handleSearch}
-            onChange={(e) => setSearchText(e.target.value)}
-          />
-          <Button type="primary" icon={<PlusOutlined />} onClick={() => setModalOpen(true)}>
-            添加 PR
-          </Button>
-        </Space>
-      </div>
+      <ListHeader
+        title="Pull Requests 列表"
+        count={pagination?.total || 0}
+        countLabel="个 PR"
+        searchPlaceholder="搜索 PR ID 或标题"
+        searchValue={searchText}
+        onSearchChange={setSearchText}
+        onSearch={handleSearch}
+        actionButton={{
+          icon: <PlusOutlined />,
+          text: '添加 PR',
+          onClick: () => setModalOpen(true)
+        }}
+      />
 
       <Card className="prs-card">
         {filteredPRs.length === 0 ? (
@@ -172,6 +169,7 @@ function PRsListContent({
             dataSource={filteredPRs}
             columns={columns}
             rowKey="id"
+            scroll={{ x: 'max-content' }}
             pagination={{
               current: page,
               pageSize,


### PR DESCRIPTION
## Summary
• 创建统一的 ListHeader 组件，统一 CAs、PRs、Issues 三个列表页面的顶部样式
• 修复列表表格超宽问题，添加横向滚动支持
• 提升代码复用性和维护性

## Changes
- 新增 `ListHeader` 组件（`packages/hr-agent-web/src/components/ListHeader/`）
  - 可配置标题、计数、搜索框和操作按钮
  - 采用玻璃拟态设计风格
  - 支持搜索值绑定和搜索事件处理
- 更新三个列表页面使用统一的 ListHeader 组件
  - CAs 列表页面
  - PRs 列表页面
  - Issues 列表页面
- 为所有列表表格添加 `scroll={{ x: 'max-content' }}` 属性
  - 解决表格内容超宽时的显示问题
  - 支持横向滚动查看完整内容

## Test Plan
- [x] TypeScript 类型检查通过
- [x] ESLint 检查通过
- [x] 代码格式化完成
- [x] 本地提交成功