### PR TITLE
fix(api): support taskId parameter in execute task endpoint

### DIFF
--- a/packages/hr-agent/src/services/taskManager.ts
+++ b/packages/hr-agent/src/services/taskManager.ts
@@ -50,4 +50,8 @@ export class TaskManager {
   async getStatus(): Promise<SchedulerStatus> {
     return this.scheduler.getStatus();
   }
+
+  async runExisting(taskId: number): Promise<number> {
+    return this.scheduler.enqueueExistingTask(taskId);
+  }
 }


### PR DESCRIPTION
## Summary

- 修复了 web 包与 hra 包之间的 API 接口不一致问题
- 前端 `executeTask` 传入 `{ taskId: number }`，后端现已支持该参数

## Changes

1. **POST /v1/tasks/execute** 增加 `taskId` 参数支持
   - 优先处理 `taskId` 参数
   - 保留原有的 `taskName/uri + params` 调用方式
   
2. **TaskScheduler.enqueueExistingTask** 新增方法
   - 将已存在的 `planned` 状态任务加入执行队列
   - 更新任务状态为 `queued`
   
3. **TaskManager.runExisting** 新增方法
   - 提供对 `enqueueExistingTask` 的访问

## API 接口一致性分析

| 接口 | 状态 |
|------|------|
| Issues CRUD | ✓ 匹配 |
| PRs CRUD | ✓ 匹配 |
| Tasks CRUD | ✓ 匹配 |
| CAs CRUD | ✓ 匹配 |
| Tasks Execute | ✓ 已修复 |

## Test plan

- [x] typecheck 通过
- [x] lint 通过 (warnings 为预先存在)
- [x] 现有测试通过