### PR TITLE
feat(ca): 统一 CA 名称前缀配置

### DIFF
--- a/packages/hr-agent-web/src/api/config.ts
+++ b/packages/hr-agent-web/src/api/config.ts
@@ -1,0 +1,10 @@
+import apiClient from './client';
+import type { ApiResponse } from '../types/api';
+
+export interface AppConfig {
+  caNamePrefix: string;
+}
+
+export const getConfig = () => {
+  return apiClient.get<ApiResponse<AppConfig>>('/v1/config');
+};

--- a/packages/hr-agent-web/src/hooks/useConfig.ts
+++ b/packages/hr-agent-web/src/hooks/useConfig.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { getConfig } from '../api/config';
+
+export function useConfig() {
+  return useQuery({
+    queryKey: ['config'],
+    queryFn: async () => {
+      const response = await getConfig();
+      return response.data.data;
+    },
+    staleTime: Infinity
+  });
+}

--- a/packages/hr-agent/src/config/docker.ts
+++ b/packages/hr-agent/src/config/docker.ts
@@ -1,8 +1,8 @@
 import { getDockerCASecret } from '../utils/secretManager.js';
+import { TASK_CONFIG } from './taskConfig.js';
 
 const MAX_PORT_NUMBER = 65536;
 const DEFAULT_DOCKER_BASE_PORT = 5000;
-const DEFAULT_NAME_PREFIX = 'hra_';
 
 const basePortInput = parseInt(
   process.env.DOCKER_BASE_PORT ?? String(DEFAULT_DOCKER_BASE_PORT),
@@ -13,8 +13,6 @@ const BASE_PORT =
     ? basePortInput
     : DEFAULT_DOCKER_BASE_PORT;
 
-const namePrefix = process.env.HRA_CA_NAME_PREFIX ?? DEFAULT_NAME_PREFIX;
-
 export const DOCKER_CONFIG = {
   IMAGE: process.env.DOCKER_CA_IMAGE ?? 'ghcr.io/eeymoo/open-hr-agent-ca:main',
   PORT: process.env.DOCKER_CA_PORT ?? '4096',
@@ -22,5 +20,5 @@ export const DOCKER_CONFIG = {
   NETWORK: process.env.DOCKER_NETWORK ?? 'hr-network',
   SECRET: getDockerCASecret(),
   HR_NETWORK: process.env.HR_NETWORK ?? 'hr-network',
-  NAME_PREFIX: namePrefix
+  NAME_PREFIX: TASK_CONFIG.CA_NAME_PREFIX
 } as const;

--- a/packages/hr-agent/src/routes/v1/ca/status.get.ts
+++ b/packages/hr-agent/src/routes/v1/ca/status.get.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import Result from '../../../utils/Result.js';
+import { TASK_CONFIG } from '../../../config/taskConfig.js';
 
 const HTTP = {
   INTERNAL_SERVER_ERROR: 500
@@ -42,8 +43,8 @@ export default async function caStatusRoute(_req: Request, res: Response): Promi
       updatedAt: ca.updatedAt,
       currentTaskId: ca.tasks[0]?.id,
       currentTaskType: ca.tasks[0]?.type,
-      issueNumber: ca.caName.replace('hra_', '')
-        ? parseInt(ca.caName.replace('hra_', ''), 10)
+      issueNumber: ca.caName.replace(TASK_CONFIG.CA_NAME_PREFIX, '')
+        ? parseInt(ca.caName.replace(TASK_CONFIG.CA_NAME_PREFIX, ''), 10)
         : undefined
     }));
 

--- a/packages/hr-agent/src/routes/v1/config.get.ts
+++ b/packages/hr-agent/src/routes/v1/config.get.ts
@@ -1,0 +1,11 @@
+import type { Request, Response } from 'express';
+import Result from '../../utils/Result.js';
+import { TASK_CONFIG } from '../../config/taskConfig.js';
+
+export default function configRoute(_req: Request, res: Response): void {
+  res.json(
+    new Result({
+      caNamePrefix: TASK_CONFIG.CA_NAME_PREFIX
+    })
+  );
+}


### PR DESCRIPTION
## Summary

- 统一 CA 名称前缀配置，通过环境变量 `HRA_CA_NAME_PREFIX` 设置，默认值为 `hra_`
- 新增 `/v1/config` 接口供前端查询前缀配置
- 前端创建 CA 时使用 `Input.addonBefore` 显示固定前缀，用户体验更直观
- 修复 `status.get.ts` 中硬编码的前缀

## Changes

**后端**
- `config/docker.ts` - 统一使用 `TASK_CONFIG.CA_NAME_PREFIX`
- `routes/v1/config.get.ts` - 新增配置查询接口
- `routes/v1/ca/status.get.ts` - 移除硬编码前缀

**前端**
- `api/config.ts` - 新增 config API
- `hooks/useConfig.ts` - 新增 useConfig hook
- `pages/CAs/index.tsx` - 创建 CA 表单显示固定前缀

## Test

- 前端 typecheck 通过
- 后端 typecheck 存在预存问题 (taskScheduler.ts tags 相关)，与本次修改无关