### PR TITLE
feat(hra): 前端需要的新增 API 接口

### DIFF
--- a/packages/hr-agent/src/index.ts
+++ b/packages/hr-agent/src/index.ts
@@ -76,11 +76,7 @@ function scheduleContainerSync(): void {
 
   syncTimeout = setTimeout(async () => {
     try {
-      const result = await taskManager.run(
-        'container_sync',
-        {},
-        CONTAINER_TASK_PRIORITIES.SYNC
-      );
+      const result = await taskManager.run('container_sync', {}, CONTAINER_TASK_PRIORITIES.SYNC);
 
       lastSyncHadInconsistency = result !== null;
     } catch (error) {

--- a/packages/hr-agent/src/routes/v1/ca/[name].delete.ts
+++ b/packages/hr-agent/src/routes/v1/ca/[name].delete.ts
@@ -47,9 +47,7 @@ export default async function deleteCARoute(req: Request, res: Response): Promis
     }
 
     if (caRecord.status === 'pending_delete' || caRecord.status === 'destroying') {
-      res.json(
-        new Result().error(HTTP.BAD_REQUEST, 'Coding agent is already pending deletion')
-      );
+      res.json(new Result().error(HTTP.BAD_REQUEST, 'Coding agent is already pending deletion'));
       return;
     }
 

--- a/packages/hr-agent/src/routes/v1/ca/add.post.ts
+++ b/packages/hr-agent/src/routes/v1/ca/add.post.ts
@@ -83,12 +83,7 @@ export default async function newCARoute(req: Request, res: Response): Promise<v
     });
 
     if (existingCA) {
-      res.json(
-        new Result().error(
-          HTTP.BAD_REQUEST,
-          'Coding agent with this name already exists'
-        )
-      );
+      res.json(new Result().error(HTTP.BAD_REQUEST, 'Coding agent with this name already exists'));
       return;
     }
 

--- a/packages/hr-agent/src/routes/v1/cas/[id].delete.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id].delete.ts
@@ -39,9 +39,7 @@ export default async function deleteCodingAgentRoute(req: Request, res: Response
     }
 
     if (existingCA.status === 'pending_delete' || existingCA.status === 'destroying') {
-      res.json(
-        new Result().error(HTTP.BAD_REQUEST, 'Coding agent is already pending deletion')
-      );
+      res.json(new Result().error(HTTP.BAD_REQUEST, 'Coding agent is already pending deletion'));
       return;
     }
 

--- a/packages/hr-agent/src/routes/v1/cas/[id]/restart.post.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id]/restart.post.ts
@@ -77,10 +77,7 @@ export default async function restartCARoute(req: Request, res: Response): Promi
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
     res.json(
-      new Result().error(
-        HTTP.INTERNAL_SERVER_ERROR,
-        `Failed to restart container: ${errorMessage}`
-      )
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to restart container: ${errorMessage}`)
     );
   }
 }

--- a/packages/hr-agent/src/routes/v1/cas/[id]/start.post.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id]/start.post.ts
@@ -77,10 +77,7 @@ export default async function startCARoute(req: Request, res: Response): Promise
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
     res.json(
-      new Result().error(
-        HTTP.INTERNAL_SERVER_ERROR,
-        `Failed to start container: ${errorMessage}`
-      )
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to start container: ${errorMessage}`)
     );
   }
 }

--- a/packages/hr-agent/src/routes/v1/cas/[id]/stop.post.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id]/stop.post.ts
@@ -77,10 +77,7 @@ export default async function stopCARoute(req: Request, res: Response): Promise<
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
     res.json(
-      new Result().error(
-        HTTP.INTERNAL_SERVER_ERROR,
-        `Failed to stop container: ${errorMessage}`
-      )
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to stop container: ${errorMessage}`)
     );
   }
 }

--- a/packages/hr-agent/src/routes/v1/cas/[id]/sync.post.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id]/sync.post.ts
@@ -63,10 +63,7 @@ export default async function syncCARoute(req: Request, res: Response): Promise<
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
     res.json(
-      new Result().error(
-        HTTP.INTERNAL_SERVER_ERROR,
-        `Failed to sync container: ${errorMessage}`
-      )
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to sync container: ${errorMessage}`)
     );
   }
 }

--- a/packages/hr-agent/src/routes/v1/issues/[id]/wait.post.ts
+++ b/packages/hr-agent/src/routes/v1/issues/[id]/wait.post.ts
@@ -1,0 +1,85 @@
+import type { Request, Response } from 'express';
+import Result from '../../../../utils/Result.js';
+import { getPrismaClient, SOFT_DELETE_FLAG } from '../../../../utils/database.js';
+
+const HTTP = {
+  BAD_REQUEST: 400,
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_FOUND: 404,
+  REQUEST_TIMEOUT: 408
+};
+
+const DEFAULT_TIMEOUT = 120;
+const POLL_INTERVAL = 2000;
+
+interface WaitIssueBody {
+  timeout?: number;
+}
+
+export default async function waitIssueRoute(req: Request, res: Response): Promise<void> {
+  const prisma = getPrismaClient();
+  const { id } = req.params;
+  const body = req.body as WaitIssueBody;
+
+  const issueId = parseInt(Array.isArray(id) ? id[0] : id, 10);
+
+  if (isNaN(issueId)) {
+    res.json(new Result().error(HTTP.BAD_REQUEST, 'Invalid issue ID'));
+    return;
+  }
+
+  const timeout =
+    typeof body.timeout === 'number' && body.timeout > 0 ? body.timeout : DEFAULT_TIMEOUT;
+
+  try {
+    const existingIssue = await prisma.issue.findFirst({
+      where: {
+        id: issueId,
+        deletedAt: SOFT_DELETE_FLAG
+      }
+    });
+
+    if (!existingIssue) {
+      res.json(new Result().error(HTTP.NOT_FOUND, 'Issue not found'));
+      return;
+    }
+
+    if (existingIssue.completedAt > SOFT_DELETE_FLAG) {
+      res.json(new Result(existingIssue));
+      return;
+    }
+
+    const startTime = Date.now();
+    const timeoutMs = timeout * 1000;
+
+    while (Date.now() - startTime < timeoutMs) {
+      const issue = await prisma.issue.findFirst({
+        where: {
+          id: issueId,
+          deletedAt: SOFT_DELETE_FLAG
+        }
+      });
+
+      if (!issue) {
+        res.json(new Result().error(HTTP.NOT_FOUND, 'Issue not found'));
+        return;
+      }
+
+      if (issue.completedAt > SOFT_DELETE_FLAG) {
+        res.json(new Result(issue));
+        return;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+    }
+
+    res.json(
+      new Result().error(HTTP.REQUEST_TIMEOUT, `Issue not completed within ${timeout} seconds`)
+    );
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    res.json(
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to wait for issue: ${errorMessage}`)
+    );
+  }
+}

--- a/packages/hr-agent/src/routes/v1/tasks/reorder.post.ts
+++ b/packages/hr-agent/src/routes/v1/tasks/reorder.post.ts
@@ -1,0 +1,63 @@
+import type { Request, Response } from 'express';
+import Result from '../../../utils/Result.js';
+import { getPrismaClient } from '../../../utils/database.js';
+
+const HTTP = {
+  BAD_REQUEST: 400,
+  INTERNAL_SERVER_ERROR: 500
+};
+
+interface TaskOrder {
+  taskId: number;
+  priority: number;
+}
+
+interface ReorderTasksBody {
+  taskOrders: TaskOrder[];
+}
+
+export default async function reorderTasksRoute(req: Request, res: Response): Promise<void> {
+  const prisma = getPrismaClient();
+  const body = req.body as ReorderTasksBody;
+
+  if (!body.taskOrders || !Array.isArray(body.taskOrders) || body.taskOrders.length === 0) {
+    res.json(
+      new Result().error(HTTP.BAD_REQUEST, 'taskOrders is required and must be a non-empty array')
+    );
+    return;
+  }
+
+  for (const item of body.taskOrders) {
+    if (typeof item.taskId !== 'number' || typeof item.priority !== 'number') {
+      res.json(
+        new Result().error(
+          HTTP.BAD_REQUEST,
+          'Each item must have taskId (number) and priority (number)'
+        )
+      );
+      return;
+    }
+  }
+
+  try {
+    const timestamp = Math.floor(Date.now() / 1000);
+    await prisma.$transaction(
+      body.taskOrders.map((item) =>
+        prisma.task.update({
+          where: { id: item.taskId },
+          data: {
+            priority: item.priority,
+            updatedAt: timestamp
+          }
+        })
+      )
+    );
+
+    res.json(new Result(null));
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+    res.json(
+      new Result().error(HTTP.INTERNAL_SERVER_ERROR, `Failed to reorder tasks: ${errorMessage}`)
+    );
+  }
+}

--- a/packages/hr-agent/src/routes/v1/tasks/reorder.test.ts
+++ b/packages/hr-agent/src/routes/v1/tasks/reorder.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  REQUEST_TIMEOUT: 408
+} as const;
+
+const mockTaskUpdate = vi.fn().mockResolvedValue({ id: 1, priority: 20 });
+const mockIssueFindFirst = vi.fn().mockResolvedValue(null);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    task: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: mockTaskUpdate,
+      delete: vi.fn().mockResolvedValue({ id: 1 })
+    },
+    issue: {
+      findMany: vi.fn().mockResolvedValue([]),
+      findFirst: mockIssueFindFirst,
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+      delete: vi.fn().mockResolvedValue({ id: 1 })
+    },
+    $transaction: vi.fn().mockImplementation((promises) => Promise.all(promises)),
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+describe('Tasks Reorder Route Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('POST /v1/tasks/reorder', () => {
+    it('应该成功批量更新任务优先级', async () => {
+      const response = await request(app)
+        .post('/v1/tasks/reorder')
+        .send({
+          taskOrders: [
+            { taskId: 1, priority: 10 },
+            { taskId: 2, priority: 20 },
+            { taskId: 3, priority: 30 }
+          ]
+        });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('message', 'success');
+    });
+
+    it('应该在 taskOrders 缺失时返回 400 错误', async () => {
+      const response = await request(app).post('/v1/tasks/reorder').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('taskOrders is required');
+    });
+
+    it('应该在 taskOrders 为空数组时返回 400 错误', async () => {
+      const response = await request(app).post('/v1/tasks/reorder').send({ taskOrders: [] });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('non-empty array');
+    });
+
+    it('应该在 taskId 不是数字时返回 400 错误', async () => {
+      const response = await request(app)
+        .post('/v1/tasks/reorder')
+        .send({
+          taskOrders: [{ taskId: 'invalid', priority: 10 }]
+        });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('taskId (number) and priority (number)');
+    });
+
+    it('应该在 priority 不是数字时返回 400 错误', async () => {
+      const response = await request(app)
+        .post('/v1/tasks/reorder')
+        .send({
+          taskOrders: [{ taskId: 1, priority: 'high' }]
+        });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('taskId (number) and priority (number)');
+    });
+  });
+
+  describe('POST /v1/issues/:id/wait', () => {
+    it('应该在 issue 不存在时返回 404 错误', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).post('/v1/issues/999/wait').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+      expect(response.body.message).toContain('Issue not found');
+    });
+
+    it('应该在 issue ID 无效时返回 400 错误', async () => {
+      const response = await request(app).post('/v1/issues/invalid/wait').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('Invalid issue ID');
+    });
+
+    it('应该在 issue 已完成时立即返回', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123,
+        completedAt: 1739380000
+      });
+
+      const response = await request(app).post('/v1/issues/1/wait').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('id', 1);
+    });
+  });
+});

--- a/packages/hr-agent/src/services/caResourceManager.ts
+++ b/packages/hr-agent/src/services/caResourceManager.ts
@@ -441,7 +441,11 @@ export class CAResourceManager {
 
       if (!dockerContainer) {
         if (status === 'idle' || status === 'creating' || status === 'busy') {
-          await this.logger.warn(0, 'CAResourceManager', `CA ${caRecord.caName} 容器不存在，标记为 not_found`);
+          await this.logger.warn(
+            0,
+            'CAResourceManager',
+            `CA ${caRecord.caName} 容器不存在，标记为 not_found`
+          );
           await prisma.codingAgent.update({
             where: { id: caRecord.id },
             data: { status: 'not_found' }

--- a/packages/hr-agent/src/services/caStatusSyncService.ts
+++ b/packages/hr-agent/src/services/caStatusSyncService.ts
@@ -68,12 +68,8 @@ export class CAStatusSyncService {
     try {
       const results = await this.syncAllCA();
 
-      const {
-        syncedCount,
-        inconsistenciesFound,
-        errorCount,
-        notFoundCount
-      } = this.summarizeResults(results);
+      const { syncedCount, inconsistenciesFound, errorCount, notFoundCount } =
+        this.summarizeResults(results);
 
       console.log('[CAStatusSync] Sync completed:');
       console.log(`  - Total checked: ${results.length}`);
@@ -146,7 +142,11 @@ export class CAStatusSyncService {
       }
 
       if (!dockerContainer && !caRecord.containerId) {
-        if (caRecord.status === 'error' || caRecord.status === 'destroying' || caRecord.status === 'not_found') {
+        if (
+          caRecord.status === 'error' ||
+          caRecord.status === 'destroying' ||
+          caRecord.status === 'not_found'
+        ) {
           return result;
         }
 

--- a/packages/hr-agent/src/services/taskScheduler.ts
+++ b/packages/hr-agent/src/services/taskScheduler.ts
@@ -514,9 +514,14 @@ export class TaskScheduler {
       const ca = await this.allocateCAForTask(task);
 
       if (!ca) {
-        await this.logger.warn(task.taskId, 'Scheduler', 'CA 分配失败，任务重新入队，继续调度下一个任务', {
-          taskName: task.taskName
-        });
+        await this.logger.warn(
+          task.taskId,
+          'Scheduler',
+          'CA 分配失败，任务重新入队，继续调度下一个任务',
+          {
+            taskName: task.taskName
+          }
+        );
         this.taskQueue.enqueue(task);
         await this.scheduleNext();
         return;


### PR DESCRIPTION
## 概述

Closes #138

前端任务管理功能升级需要的后端 API 接口支持。

## 新增 API

### 1. POST /v1/tasks/reorder - 批量更新任务优先级

用于拖拽排序后保存顺序。

**请求体：**
```json
{
  "taskOrders": [
    { "taskId": 1, "priority": 10 },
    { "taskId": 2, "priority": 20 }
  ]
}
```

### 2. POST /v1/issues/:id/wait - 等待 Issue 完成

等待指定 issue 完成（可设置超时）。

**请求体：**
```json
{
  "timeout": 120
}
```

## 文件变更

- `src/routes/v1/tasks/reorder.post.ts` - 新增批量更新任务优先级接口
- `src/routes/v1/issues/[id]/wait.post.ts` - 新增等待 issue 完成接口
- `src/routes/v1/tasks/reorder.test.ts` - 测试文件

## 测试

- 新增 API 测试全部通过
- 类型检查通过
- Lint 检查通过（仅有警告，无错误）