### PR TITLE
feat(hr-agent-web): 新增任务列表页面及拖拽排序功能

### DIFF
--- a/packages/hr-agent-web/src/api/tasks.ts
+++ b/packages/hr-agent-web/src/api/tasks.ts
@@ -1,58 +1,37 @@
 import apiClient from './client';
 import type { ApiResponse, TasksListResponse } from '../types/api';
-import type { Task, CreateTaskDto, UpdateTaskDto, TaskQueryParams } from '../types/task';
+import type {
+  Task,
+  CreateTaskDto,
+  UpdateTaskDto,
+  TaskQueryParams,
+  ReorderTasksDto
+} from '../types/task';
 
-/**
- * 获取任务列表
- * @param params - 查询和分页参数
- * @returns API 响应，包含任务列表和分页信息
- */
 export const getTasks = (params?: TaskQueryParams) => {
   return apiClient.get<ApiResponse<TasksListResponse>>('/v1/tasks', { params });
 };
 
-/**
- * 根据 ID 获取指定任务
- * @param id - 任务 ID
- * @returns API 响应，包含任务对象
- */
 export const getTask = (id: number) => {
   return apiClient.get<ApiResponse<Task>>(`/v1/tasks/${id}`);
 };
 
-/**
- * 创建新任务
- * @param data - 任务数据
- * @returns API 响应，包含创建的任务
- */
 export const createTask = (data: CreateTaskDto) => {
   return apiClient.post<ApiResponse<Task>>('/v1/tasks', data);
 };
 
-/**
- * 更新任务
- * @param id - 任务 ID
- * @param data - 更新数据
- * @returns API 响应，包含更新后的任务
- */
 export const updateTask = (id: number, data: UpdateTaskDto) => {
   return apiClient.put<ApiResponse<Task>>(`/v1/tasks/${id}`, data);
 };
 
-/**
- * 删除任务
- * @param id - 任务 ID
- * @returns API 响应
- */
 export const deleteTask = (id: number) => {
   return apiClient.delete<ApiResponse<void>>(`/v1/tasks/${id}`);
 };
 
-/**
- * 执行任务
- * @param id - 任务 ID
- * @returns API 响应
- */
 export const executeTask = (id: number) => {
   return apiClient.post<ApiResponse<void>>('/v1/tasks/execute', { taskId: id });
+};
+
+export const reorderTasks = (data: ReorderTasksDto) => {
+  return apiClient.post<ApiResponse<void>>('/v1/tasks/reorder', data);
 };

--- a/packages/hr-agent-web/src/components/Layout/index.tsx
+++ b/packages/hr-agent-web/src/components/Layout/index.tsx
@@ -7,7 +7,8 @@ import {
   RobotOutlined,
   IssuesCloseOutlined,
   PullRequestOutlined,
-  CodeOutlined
+  CodeOutlined,
+  UnorderedListOutlined
 } from '@ant-design/icons';
 import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
@@ -40,9 +41,14 @@ export function AppLayout({ children }: LayoutProps) {
 
   const menuItems = [
     {
-      key: '/orchestration',
+      key: '/tasks',
       icon: <AppstoreOutlined />,
       label: '任务编排'
+    },
+    {
+      key: '/tasks/list',
+      icon: <UnorderedListOutlined />,
+      label: '任务列表'
     },
     {
       key: '/issues',
@@ -79,6 +85,12 @@ export function AppLayout({ children }: LayoutProps) {
   ];
 
   const getPageTitle = () => {
+    if (location.pathname === '/tasks/list') {
+      return '任务列表';
+    }
+    if (location.pathname === '/tasks') {
+      return '任务编排工作台';
+    }
     if (location.pathname.startsWith('/issues')) {
       return 'Issues 管理';
     }
@@ -87,9 +99,6 @@ export function AppLayout({ children }: LayoutProps) {
     }
     if (location.pathname.startsWith('/cas')) {
       return 'Coding Agents 管理';
-    }
-    if (location.pathname === '/orchestration') {
-      return '任务编排工作台';
     }
     return 'HR Agent';
   };
@@ -109,7 +118,11 @@ export function AppLayout({ children }: LayoutProps) {
 
         <Menu
           mode="inline"
-          selectedKeys={[location.pathname]}
+          selectedKeys={[
+            location.pathname.startsWith('/tasks') && location.pathname !== '/tasks/list'
+              ? '/tasks'
+              : location.pathname
+          ]}
           items={menuItems}
           onClick={handleMenuClick}
           className="app-menu"

--- a/packages/hr-agent-web/src/components/TaskFormModal/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskFormModal/index.tsx
@@ -1,6 +1,9 @@
 import { Modal, Form, Input, Select, InputNumber, Button } from 'antd';
 import {
   TASK_STATUS_LABELS,
+  PRIORITY_LOW,
+  PRIORITY_MEDIUM,
+  PRIORITY_HIGH,
   type Task,
   type CreateTaskDto,
   type UpdateTaskDto
@@ -54,7 +57,7 @@ export function TaskFormModal({
         initialValues={{
           type: task?.type || '',
           status: task?.status || 'queued',
-          priority: task?.priority ?? 50
+          priority: task?.priority ?? PRIORITY_MEDIUM
         }}
       >
         <Form.Item
@@ -87,9 +90,9 @@ export function TaskFormModal({
           rules={[{ required: true, message: '请选择优先级' }]}
         >
           <Select placeholder="选择优先级">
-            <Select.Option value={0}>低</Select.Option>
-            <Select.Option value={50}>中</Select.Option>
-            <Select.Option value={100}>高</Select.Option>
+            <Select.Option value={PRIORITY_LOW}>低</Select.Option>
+            <Select.Option value={PRIORITY_MEDIUM}>中</Select.Option>
+            <Select.Option value={PRIORITY_HIGH}>高</Select.Option>
           </Select>
         </Form.Item>
 

--- a/packages/hr-agent-web/src/components/TaskKanban/index.css
+++ b/packages/hr-agent-web/src/components/TaskKanban/index.css
@@ -65,6 +65,31 @@
   padding: 3px 10px;
   border-radius: 8px;
   font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.kanban-column.kanban-reordering {
+  border-color: var(--purple-main) !important;
+  box-shadow:
+    0 0 20px rgba(139, 92, 246, 0.2),
+    var(--shadow-card);
+}
+
+.kanban-column.kanban-reordering::before {
+  background: linear-gradient(90deg, var(--purple-main), var(--purple-light), var(--purple-main));
+  background-size: 200% 100%;
+  animation: shimmer 2s linear infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .task-list {

--- a/packages/hr-agent-web/src/hooks/useTasks.ts
+++ b/packages/hr-agent-web/src/hooks/useTasks.ts
@@ -1,7 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getTasks, getTask, createTask, updateTask, deleteTask, executeTask } from '../api/tasks';
+import {
+  getTasks,
+  getTask,
+  createTask,
+  updateTask,
+  deleteTask,
+  executeTask,
+  reorderTasks
+} from '../api/tasks';
 import { POLLING_INTERVAL } from '../utils/constants';
-import type { CreateTaskDto, UpdateTaskDto, TaskQueryParams } from '../types/task';
+import type { CreateTaskDto, UpdateTaskDto, TaskQueryParams, ReorderTasksDto } from '../types/task';
 
 export function useTasks(params?: TaskQueryParams) {
   return useQuery({
@@ -64,6 +72,17 @@ export function useExecuteTask() {
 
   return useMutation({
     mutationFn: (id: number) => executeTask(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks'] });
+    }
+  });
+}
+
+export function useReorderTasks() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ReorderTasksDto) => reorderTasks(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
     }

--- a/packages/hr-agent-web/src/pages/TaskList/columns.tsx
+++ b/packages/hr-agent-web/src/pages/TaskList/columns.tsx
@@ -1,0 +1,294 @@
+import { Space, Tag, Button, Tooltip, Progress } from 'antd';
+import {
+  GithubOutlined,
+  LinkOutlined,
+  ClockCircleOutlined,
+  RobotOutlined,
+  CheckCircleOutlined,
+  ExclamationCircleOutlined,
+  LoadingOutlined
+} from '@ant-design/icons';
+import type { ColumnsType } from 'antd/es/table';
+import {
+  TASK_STATUS_LABELS,
+  TASK_STATUS_COLORS,
+  PRIORITY_COLORS,
+  PRIORITY_LABELS,
+  PRIORITY_LOW,
+  PRIORITY_MEDIUM,
+  PRIORITY_HIGH,
+  type Task,
+  type TaskStatus
+} from '../../types/task';
+import { formatTimestamp, formatRelativeTime } from '../../utils/formatters';
+import { CA_BASE_URL } from '../../utils/constants';
+
+const RUNNING_STATUSES = ['running', 'retrying', 'in_development'];
+const ERROR_STATUSES = ['error', 'timeout'];
+const COLOR_BLUE = '#3b82f6';
+const COLOR_GREEN = '#10b981';
+const COLOR_RED = '#ef4444';
+const COLOR_GRAY = '#6b7280';
+const COLOR_PURPLE = '#9333EA';
+
+const getStatusIcon = (status: TaskStatus) => {
+  switch (status) {
+    case 'running':
+    case 'retrying':
+    case 'in_development':
+      return <LoadingOutlined spin style={{ color: COLOR_BLUE }} />;
+    case 'pr_merged':
+    case 'development_complete':
+      return <CheckCircleOutlined style={{ color: COLOR_GREEN }} />;
+    case 'error':
+    case 'timeout':
+      return <ExclamationCircleOutlined style={{ color: COLOR_RED }} />;
+    default:
+      return <ClockCircleOutlined style={{ color: COLOR_GRAY }} />;
+  }
+};
+
+const getProgressByStatus = (status: TaskStatus): number => {
+  const progressMap: Record<TaskStatus, number> = {
+    planned: 0,
+    queued: 0,
+    running: 50,
+    retrying: 50,
+    in_development: 70,
+    development_complete: 80,
+    pr_submitted: 90,
+    pr_merged: 100,
+    pr_comments_resolved: 95,
+    error: 0,
+    cancelled: 0,
+    timeout: 0
+  };
+  return progressMap[status] ?? 0;
+};
+
+export const isRunningStatus = (status: TaskStatus): boolean => {
+  return RUNNING_STATUSES.includes(status);
+};
+
+const renderIssueColumn = (_: unknown, record: Task) => {
+  if (!record.issue) {
+    return <span className="task-list-empty">-</span>;
+  }
+  return (
+    <Tooltip title={record.issue?.issueTitle}>
+      <Button
+        type="link"
+        size="small"
+        icon={<GithubOutlined />}
+        onClick={() => {
+          if (record.issue) {
+            window.open(record.issue.issueUrl, '_blank');
+          }
+        }}
+        className="task-list-link"
+      >
+        #{record.issue.issueId}
+      </Button>
+    </Tooltip>
+  );
+};
+
+const renderPRColumn = (_: unknown, record: Task) => {
+  if (!record.pullRequest) {
+    return <span className="task-list-empty">-</span>;
+  }
+  return (
+    <Button
+      type="link"
+      size="small"
+      icon={<GithubOutlined />}
+      onClick={() => {
+        if (record.pullRequest) {
+          window.open(record.pullRequest.prUrl, '_blank');
+        }
+      }}
+      className="task-list-link"
+    >
+      #{record.pullRequest.prId}
+    </Button>
+  );
+};
+
+const renderCAColumn = (_: unknown, record: Task) => {
+  if (!record.codingAgent) {
+    return <span className="task-list-empty">-</span>;
+  }
+  return (
+    <Button
+      type="link"
+      size="small"
+      icon={<LinkOutlined />}
+      onClick={() => {
+        window.open(CA_BASE_URL, '_blank');
+      }}
+      className="task-list-link"
+    >
+      {record.codingAgent.caName}
+    </Button>
+  );
+};
+
+export const getTaskListColumns = (onNavigate: (path: string) => void): ColumnsType<Task> => [
+  {
+    title: 'ID',
+    dataIndex: 'id',
+    key: 'id',
+    width: 80,
+    fixed: 'left',
+    render: (id: number) => (
+      <span
+        className="task-list-id"
+        onClick={() => {
+          onNavigate('/tasks');
+        }}
+      >
+        #{id}
+      </span>
+    )
+  },
+  {
+    title: '状态',
+    dataIndex: 'status',
+    key: 'status',
+    width: 140,
+    render: (status: TaskStatus) => (
+      <Space size={4}>
+        {getStatusIcon(status)}
+        <Tag color={TASK_STATUS_COLORS[status]} className="task-list-status-tag">
+          {TASK_STATUS_LABELS[status]}
+        </Tag>
+      </Space>
+    ),
+    sorter: (a: Task, b: Task) => a.status.localeCompare(b.status)
+  },
+  {
+    title: '进度',
+    key: 'progress',
+    width: 150,
+    render: (_: unknown, record: Task) => {
+      const progress = getProgressByStatus(record.status);
+      const isRunning = isRunningStatus(record.status);
+      return (
+        <div className="task-list-progress">
+          <Progress
+            percent={progress}
+            size="small"
+            strokeColor={isRunning ? COLOR_BLUE : COLOR_PURPLE}
+            showInfo={false}
+            className={isRunning ? 'progress-animated' : ''}
+          />
+          <span className="progress-text">{progress}%</span>
+        </div>
+      );
+    }
+  },
+  {
+    title: '类型',
+    dataIndex: 'type',
+    key: 'type',
+    width: 150,
+    render: (type: string) => (
+      <Space size={6}>
+        <RobotOutlined className="task-list-type-icon" />
+        <span>{type}</span>
+      </Space>
+    )
+  },
+  {
+    title: '优先级',
+    dataIndex: 'priority',
+    key: 'priority',
+    width: 90,
+    render: (priority: number) => (
+      <Tag color={PRIORITY_COLORS[priority] ?? 'default'} className="task-list-priority-tag">
+        {PRIORITY_LABELS[priority] ?? '未知'}
+      </Tag>
+    ),
+    sorter: (a: Task, b: Task) => a.priority - b.priority
+  },
+  {
+    title: 'Issue',
+    key: 'issue',
+    width: 180,
+    render: renderIssueColumn
+  },
+  {
+    title: 'PR',
+    key: 'pr',
+    width: 120,
+    render: renderPRColumn
+  },
+  {
+    title: 'CA',
+    key: 'ca',
+    width: 120,
+    render: renderCAColumn
+  },
+  {
+    title: '创建时间',
+    dataIndex: 'createdAt',
+    key: 'createdAt',
+    width: 160,
+    render: (timestamp: number) => (
+      <Tooltip title={formatTimestamp(timestamp)}>
+        <span className="task-list-time">{formatRelativeTime(timestamp)}</span>
+      </Tooltip>
+    ),
+    sorter: (a: Task, b: Task) => a.createdAt - b.createdAt,
+    defaultSortOrder: 'descend'
+  },
+  {
+    title: '更新时间',
+    dataIndex: 'updatedAt',
+    key: 'updatedAt',
+    width: 160,
+    render: (timestamp: number) => (
+      <Tooltip title={formatTimestamp(timestamp)}>
+        <span className="task-list-time">{formatRelativeTime(timestamp)}</span>
+      </Tooltip>
+    ),
+    sorter: (a: Task, b: Task) => a.updatedAt - b.updatedAt
+  }
+];
+
+export const calculateStatusCounts = (tasks: Task[]) => {
+  const counts = {
+    all: tasks.length,
+    queued: 0,
+    running: 0,
+    completed: 0,
+    error: 0
+  };
+  tasks.forEach((task: Task) => {
+    if (task.status === 'queued') {
+      counts.queued++;
+    } else if (RUNNING_STATUSES.includes(task.status)) {
+      counts.running++;
+    } else if (task.status === 'pr_merged') {
+      counts.completed++;
+    } else if (ERROR_STATUSES.includes(task.status)) {
+      counts.error++;
+    }
+  });
+  return counts;
+};
+
+export const STATUS_FILTER_OPTIONS = [
+  { value: 'all', label: '全部状态' },
+  { value: 'queued', label: '排队中' },
+  { value: 'running', label: '运行中' },
+  { value: 'pr_merged', label: '已完成' },
+  { value: 'error', label: '错误' }
+];
+
+export const PRIORITY_FILTER_OPTIONS = [
+  { value: 'all', label: '全部优先级' },
+  { value: PRIORITY_HIGH, label: '高' },
+  { value: PRIORITY_MEDIUM, label: '中' },
+  { value: PRIORITY_LOW, label: '低' }
+];

--- a/packages/hr-agent-web/src/pages/TaskList/index.css
+++ b/packages/hr-agent-web/src/pages/TaskList/index.css
@@ -1,0 +1,245 @@
+.task-list-page {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.task-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 20px 24px;
+  background: var(--bg-glass);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-glass);
+  border-radius: 16px;
+  box-shadow: var(--shadow-card);
+  position: relative;
+  overflow: hidden;
+}
+
+.task-list-header::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--purple-main), var(--accent-cyan));
+}
+
+.task-list-header-left h2 {
+  margin: 0 0 8px 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.task-list-stats {
+  font-size: 13px;
+}
+
+.task-list-stats .ant-badge-status-text {
+  color: var(--text-secondary);
+}
+
+.task-list-header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.task-list-card {
+  background: var(--bg-glass) !important;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid var(--border-glass) !important;
+  border-radius: 16px !important;
+  box-shadow: var(--shadow-card);
+}
+
+.task-list-card .ant-table {
+  background: transparent !important;
+}
+
+.task-list-card .ant-table-thead > tr > th {
+  background: var(--bg-glass-light) !important;
+  border-bottom: 1px solid var(--border-glass) !important;
+  color: var(--text-secondary) !important;
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.task-list-card .ant-table-tbody > tr > td {
+  border-bottom: 1px solid var(--border-glass) !important;
+  background: transparent !important;
+  color: var(--text-primary);
+}
+
+.task-list-card .ant-table-tbody > tr:hover > td {
+  background: var(--bg-glass-hover) !important;
+}
+
+.task-list-card .ant-table-tbody > tr.task-list-row-running > td {
+  background: rgba(59, 130, 246, 0.05) !important;
+}
+
+.task-list-card .ant-table-tbody > tr.task-list-row-running:hover > td {
+  background: rgba(59, 130, 246, 0.08) !important;
+}
+
+.task-list-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 600;
+  color: var(--purple-light);
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.task-list-id:hover {
+  color: var(--purple-main);
+}
+
+.task-list-status-tag,
+.task-list-priority-tag {
+  border-radius: 6px !important;
+  font-size: 12px;
+  padding: 2px 10px !important;
+  border: none !important;
+}
+
+.task-list-progress {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.task-list-progress .ant-progress {
+  flex: 1;
+}
+
+.task-list-progress .ant-progress-bg {
+  transition: width 0.3s ease;
+}
+
+.task-list-progress .progress-animated .ant-progress-bg {
+  animation: progress-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes progress-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.task-list-progress .progress-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-weight: 500;
+  min-width: 35px;
+}
+
+.task-list-type-icon {
+  color: var(--purple-light);
+}
+
+.task-list-link {
+  padding: 0 !important;
+  height: auto !important;
+  font-size: 13px;
+  color: var(--text-secondary) !important;
+}
+
+.task-list-link:hover {
+  color: var(--purple-light) !important;
+}
+
+.task-list-empty {
+  color: var(--text-muted);
+}
+
+.task-list-time {
+  font-size: 13px;
+  color: var(--text-secondary);
+}
+
+.task-list-card .ant-pagination {
+  margin: 16px 0 0 0 !important;
+}
+
+.task-list-card .ant-pagination-item,
+.task-list-card .ant-pagination-prev,
+.task-list-card .ant-pagination-next {
+  background: var(--bg-glass-light) !important;
+  border-color: var(--border-glass) !important;
+}
+
+.task-list-card .ant-pagination-item a {
+  color: var(--text-secondary) !important;
+}
+
+.task-list-card .ant-pagination-item-active {
+  background: var(--purple-main) !important;
+  border-color: var(--purple-main) !important;
+}
+
+.task-list-card .ant-pagination-item-active a {
+  color: white !important;
+}
+
+@media (max-width: 1024px) {
+  .task-list-header {
+    padding: 16px 20px;
+  }
+
+  .task-list-header-left h2 {
+    font-size: 18px;
+  }
+
+  .task-list-stats {
+    font-size: 12px;
+  }
+
+  .task-list-header-right {
+    width: 100%;
+  }
+
+  .task-list-header-right .ant-input-search {
+    width: 100% !important;
+  }
+}
+
+@media (max-width: 768px) {
+  .task-list-page {
+    gap: 16px;
+  }
+
+  .task-list-header {
+    padding: 14px 16px;
+    border-radius: 14px;
+  }
+
+  .task-list-header-left h2 {
+    font-size: 16px;
+  }
+
+  .task-list-card {
+    border-radius: 14px !important;
+  }
+
+  .task-list-header-right {
+    gap: 8px;
+  }
+
+  .task-list-header-right .ant-select {
+    width: 100% !important;
+  }
+}

--- a/packages/hr-agent-web/src/pages/TaskList/index.tsx
+++ b/packages/hr-agent-web/src/pages/TaskList/index.tsx
@@ -1,0 +1,147 @@
+import { useState, useMemo } from 'react';
+import { Card, Table, Space, Badge, Input, Select, Button } from 'antd';
+import { ReloadOutlined } from '@ant-design/icons';
+import { useTasks } from '../../hooks/useTasks';
+import { useNavigate } from 'react-router-dom';
+import type { Task, TaskStatus } from '../../types/task';
+import {
+  getTaskListColumns,
+  calculateStatusCounts,
+  isRunningStatus,
+  STATUS_FILTER_OPTIONS,
+  PRIORITY_FILTER_OPTIONS
+} from './columns';
+import './index.css';
+
+export function TaskList() {
+  const navigate = useNavigate();
+  const { data, isLoading, refetch } = useTasks();
+  const [searchText, setSearchText] = useState('');
+  const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
+  const [priorityFilter, setPriorityFilter] = useState<number | 'all'>('all');
+
+  const tasks = useMemo(() => {
+    return data?.tasks || [];
+  }, [data?.tasks]);
+
+  const filteredTasks = useMemo(() => {
+    return tasks.filter((task: Task) => {
+      const matchesSearch =
+        !searchText ||
+        task.id.toString().includes(searchText) ||
+        task.type.toLowerCase().includes(searchText.toLowerCase()) ||
+        (task.issue?.issueTitle?.toLowerCase().includes(searchText.toLowerCase()) ?? false);
+
+      const matchesStatus = statusFilter === 'all' || task.status === statusFilter;
+      const matchesPriority = priorityFilter === 'all' || task.priority === priorityFilter;
+
+      return matchesSearch && matchesStatus && matchesPriority;
+    });
+  }, [tasks, searchText, statusFilter, priorityFilter]);
+
+  const columns = getTaskListColumns(navigate);
+  const statusCounts = calculateStatusCounts(tasks);
+
+  return (
+    <div className="task-list-page">
+      <TaskListHeader
+        statusCounts={statusCounts}
+        searchText={searchText}
+        onSearchChange={setSearchText}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        priorityFilter={priorityFilter}
+        onPriorityFilterChange={setPriorityFilter}
+        onRefresh={refetch}
+      />
+      <Card className="task-list-card">
+        <Table
+          dataSource={filteredTasks}
+          columns={columns}
+          rowKey="id"
+          loading={isLoading}
+          scroll={{ x: 1400 }}
+          pagination={{
+            showSizeChanger: true,
+            showTotal: (total) => `共 ${total} 条`,
+            pageSizeOptions: ['10', '20', '50', '100']
+          }}
+          rowClassName={(record: Task) =>
+            isRunningStatus(record.status) ? 'task-list-row-running' : ''
+          }
+        />
+      </Card>
+    </div>
+  );
+}
+
+interface TaskListHeaderProps {
+  statusCounts: {
+    all: number;
+    queued: number;
+    running: number;
+    completed: number;
+    error: number;
+  };
+  searchText: string;
+  onSearchChange: (value: string) => void;
+  statusFilter: TaskStatus | 'all';
+  onStatusFilterChange: (value: TaskStatus | 'all') => void;
+  priorityFilter: number | 'all';
+  onPriorityFilterChange: (value: number | 'all') => void;
+  onRefresh: () => void;
+}
+
+function TaskListHeader({
+  statusCounts,
+  searchText,
+  onSearchChange,
+  statusFilter,
+  onStatusFilterChange,
+  priorityFilter,
+  onPriorityFilterChange,
+  onRefresh
+}: TaskListHeaderProps) {
+  return (
+    <div className="task-list-header">
+      <div className="task-list-header-left">
+        <h2>任务列表</h2>
+        <Space size={16} className="task-list-stats">
+          <Badge status="default" text={`全部: ${statusCounts.all}`} />
+          <Badge status="processing" text={`运行中: ${statusCounts.running}`} />
+          <Badge status="success" text={`已完成: ${statusCounts.completed}`} />
+          <Badge status="error" text={`错误: ${statusCounts.error}`} />
+        </Space>
+      </div>
+      <div className="task-list-header-right">
+        <Input.Search
+          placeholder="搜索 ID、类型或 Issue 标题"
+          value={searchText}
+          onChange={(e) => onSearchChange(e.target.value)}
+          style={{ width: 280 }}
+          allowClear
+        />
+        <Select
+          value={statusFilter}
+          onChange={onStatusFilterChange}
+          style={{ width: 140 }}
+          options={STATUS_FILTER_OPTIONS}
+        />
+        <Select
+          value={priorityFilter}
+          onChange={onPriorityFilterChange}
+          style={{ width: 120 }}
+          options={PRIORITY_FILTER_OPTIONS}
+        />
+        <Button
+          icon={<ReloadOutlined />}
+          onClick={() => {
+            onRefresh();
+          }}
+        >
+          刷新
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/hr-agent-web/src/routes/index.tsx
+++ b/packages/hr-agent-web/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate, Outlet } from 'react-router-dom';
 import { Login } from '../pages/Login';
 import { TaskOrchestration } from '../pages/TaskOrchestration';
+import { TaskList } from '../pages/TaskList';
 import { IssuesList } from '../pages/Issues';
 import { IssueDetail } from '../pages/IssueDetail';
 import { PRsList } from '../pages/PRs';
@@ -30,11 +31,15 @@ export const router = createBrowserRouter([
     children: [
       {
         index: true,
-        element: <Navigate to="/orchestration" replace />
+        element: <Navigate to="/tasks" replace />
       },
       {
-        path: 'orchestration',
+        path: 'tasks',
         element: <TaskOrchestration />
+      },
+      {
+        path: 'tasks/list',
+        element: <TaskList />
       },
       {
         path: 'issues',

--- a/packages/hr-agent-web/src/types/task.ts
+++ b/packages/hr-agent-web/src/types/task.ts
@@ -96,16 +96,20 @@ export const TASK_STATUS_COLORS: Record<TaskStatus, string> = {
   timeout: 'error'
 };
 
+export const PRIORITY_LOW = 10;
+export const PRIORITY_MEDIUM = 20;
+export const PRIORITY_HIGH = 30;
+
 export const PRIORITY_LABELS: Record<number, string> = {
-  0: '低',
-  50: '中',
-  100: '高'
+  [PRIORITY_LOW]: '低',
+  [PRIORITY_MEDIUM]: '中',
+  [PRIORITY_HIGH]: '高'
 };
 
 export const PRIORITY_COLORS: Record<number, string> = {
-  0: 'default',
-  50: 'processing',
-  100: 'error'
+  [PRIORITY_LOW]: 'default',
+  [PRIORITY_MEDIUM]: 'processing',
+  [PRIORITY_HIGH]: 'error'
 };
 
 export const TASK_TAG_LABELS: Record<string, string> = {
@@ -125,3 +129,7 @@ export const TASK_TAG_COLORS: Record<string, string> = {
   'agent:test': 'cyan',
   'runtime:long': 'red'
 };
+
+export interface ReorderTasksDto {
+  taskOrders: Array<{ taskId: number; priority: number }>;
+}

--- a/packages/hr-agent-web/src/utils/formatters.tsx
+++ b/packages/hr-agent-web/src/utils/formatters.tsx
@@ -8,19 +8,13 @@ import type { PullRequest } from '../types/pr';
 dayjs.extend(relativeTime);
 dayjs.locale('zh-cn');
 
-/** 无效时间戳标记 */
 export const TIMESTAMP_NEGATIVE_TWO = -2;
 const SECONDS_PER_MINUTE = 60;
 const SECONDS_PER_HOUR = 3600;
 const SECONDS_PER_DAY = 86400;
-const PRIORITY_HIGH = 80;
-const PRIORITY_MEDIUM = 50;
+const PRIORITY_HIGH = 30;
+const PRIORITY_MEDIUM = 20;
 
-/**
- * 格式化时间戳为日期时间字符串
- * @param timestamp - Unix 时间戳（秒）
- * @returns 格式化后的日期时间字符串
- */
 export const formatTimestamp = (timestamp: number): string => {
   if (timestamp === TIMESTAMP_NEGATIVE_TWO) {
     return '-';
@@ -28,11 +22,6 @@ export const formatTimestamp = (timestamp: number): string => {
   return dayjs.unix(timestamp).format('YYYY-MM-DD HH:mm:ss');
 };
 
-/**
- * 格式化时间戳为相对时间字符串
- * @param timestamp - Unix 时间戳（秒）
- * @returns 相对时间字符串（如 "3小时前"）
- */
 export const formatRelativeTime = (timestamp: number): string => {
   if (timestamp === TIMESTAMP_NEGATIVE_TWO) {
     return '-';
@@ -40,12 +29,6 @@ export const formatRelativeTime = (timestamp: number): string => {
   return dayjs.unix(timestamp).fromNow();
 };
 
-/**
- * 格式化时间间隔
- * @param start - 开始时间戳（秒）
- * @param end - 结束时间戳（秒）
- * @returns 格式化后的持续时间字符串
- */
 export const formatDuration = (start: number, end: number): string => {
   if (start === TIMESTAMP_NEGATIVE_TWO || end === TIMESTAMP_NEGATIVE_TWO) {
     return '-';
@@ -63,12 +46,6 @@ export const formatDuration = (start: number, end: number): string => {
   return `${Math.floor(diff / SECONDS_PER_DAY)}天`;
 };
 
-/**
- * 截断文本到指定长度
- * @param text - 原始文本
- * @param maxLength - 最大长度，默认为 100
- * @returns 截断后的文本
- */
 export const truncateText = (text: string, maxLength: number = 100): string => {
   if (text.length <= maxLength) {
     return text;
@@ -76,11 +53,6 @@ export const truncateText = (text: string, maxLength: number = 100): string => {
   return `${text.slice(0, maxLength)}...`;
 };
 
-/**
- * 格式化状态为中文
- * @param status - 状态字符串
- * @returns 中文状态描述
- */
 export const formatStatus = (status: string): string => {
   const statusMap: Record<string, string> = {
     planned: '已规划',
@@ -99,11 +71,6 @@ export const formatStatus = (status: string): string => {
   return statusMap[status] || status;
 };
 
-/**
- * 格式化优先级为中文
- * @param priority - 优先级数值
- * @returns 优先级描述
- */
 export const formatPriority = (priority: number): string => {
   if (priority >= PRIORITY_HIGH) {
     return '高';


### PR DESCRIPTION
## Summary
• 新增任务列表页面（TaskList），支持高效表格展示、搜索和过滤
• 任务优先级调整为 10/20/30（低/中/高），支持拖拽排序后自动保存
• 优化任务编排工作台，支持排队中卡片拖拽调整优先级

## Changes
### 新增功能
- **TaskList 页面**: 表格视图展示所有任务，支持搜索、状态过滤、优先级过滤
- **拖拽排序**: TaskKanban 排队中卡片支持拖拽，排序后自动调用 API 保存
- **reorderTasks API**: `POST /v1/tasks/reorder` 批量更新任务优先级
- **useReorderTasks Hook**: 封装排序 API 调用逻辑

### 优先级调整
- 低: `0` → `10`
- 中: `50` → `20`
- 高: `100` → `30`

### 路由更新
- `/tasks` - 任务编排工作台（看板/卡片/表格）
- `/tasks/list` - 任务列表（新增）

### 文件变更
| 文件 | 变更 |
|------|------|
| `types/task.ts` | 优先级常量、ReorderTasksDto 类型 |
| `api/tasks.ts` | reorderTasks API |
| `hooks/useTasks.ts` | useReorderTasks Hook |
| `components/TaskKanban/` | 拖拽排序逻辑 + 样式 |
| `components/Layout/` | 导航菜单更新 |
| `pages/TaskList/` | 新增列表页面 |
| `pages/TaskOrchestration/` | 组件重构优化 |
| `routes/` | 路由配置更新 |

## Related
- #138 (后端 API 需求已解决)