### PR TITLE
perf(hr-agent): 优化 hr-agent 包体积

### DIFF
--- a/packages/hr-agent/Dockerfile
+++ b/packages/hr-agent/Dockerfile
@@ -13,15 +13,6 @@ COPY packages/hr-agent/prisma ./packages/hr-agent/prisma
 
 RUN cd packages/hr-agent && pnpm exec prisma generate && pnpm run build
 
-FROM node:22.21.1-alpine AS prod-deps
-
-WORKDIR /app
-
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-COPY packages/hr-agent/package.json ./packages/hr-agent/
-
-RUN corepack enable && pnpm install --prod --no-frozen-lockfile --ignore-scripts
-
 FROM node:22.21.1-alpine
 
 WORKDIR /app
@@ -30,19 +21,19 @@ RUN apk add --no-cache openssl
 
 RUN addgroup -S nodejs && adduser -S nodeuser -G nodejs
 
-COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=builder /app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/.prisma ./node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/.prisma
-COPY --from=builder /app/node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma ./node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma
-COPY --from=builder /app/node_modules/.pnpm/@prisma+engines@5.22.0/node_modules/@prisma ./node_modules/.pnpm/@prisma+engines@5.22.0/node_modules/@prisma
-COPY --from=builder /app/node_modules/.pnpm/prisma@5.22.0/node_modules/prisma ./node_modules/.pnpm/prisma@5.22.0/node_modules/prisma
-COPY --from=builder /app/packages/hr-agent/dist ./dist
 COPY packages/hr-agent/package.json ./package.json
 COPY packages/hr-agent/prisma ./prisma
+COPY pnpm-lock.yaml ./
+
+RUN corepack enable && \
+    pnpm install --prod --no-frozen-lockfile --ignore-scripts && \
+    pnpm add prisma@5.22.0 --ignore-scripts && \
+    pnpm exec prisma generate
+
+COPY --from=builder /app/packages/hr-agent/dist ./dist
 COPY packages/hr-agent/scripts/docker-entrypoint.sh ./docker-entrypoint.sh
 
-RUN mkdir -p node_modules/.bin && \
-    ln -s ../.pnpm/prisma@5.22.0/node_modules/prisma/build/index.js node_modules/.bin/prisma && \
-    chown -R nodeuser:nodejs /app && chmod +x docker-entrypoint.sh
+RUN chown -R nodeuser:nodejs /app && chmod +x docker-entrypoint.sh
 
 USER nodeuser
 


### PR DESCRIPTION
## Summary
- 关闭 sourceMap、declaration、declarationMap 减少构建产物
- 优化 Dockerfile，只安装生产依赖 + prisma CLI
- 本地测试通过，服务正常运行

## 效果
- **dist 目录**: 2.1M → 648K (减少 **69%**)
- **Docker 镜像**: 961MB → 873MB (减少 **9.2%**)

## Changes
- `packages/hr-agent/tsconfig.json`: 关闭 sourceMap、declaration、declarationMap
- `packages/hr-agent/Dockerfile`: 
  - 使用 pnpm install --prod 只安装生产依赖
  - 使用 pnpm add prisma 添加 prisma CLI（运行时 db push 需要）
  - 生成 Prisma 客户端

## 本地测试
- Docker 容器启动成功
- Health API 正常响应
- 所有路由正常加载

Closes #136