### PR TITLE
fix(hra): 调整认证中间件跳过路径

### DIFF
--- a/packages/hr-agent/src/middleware/validateSecret.ts
+++ b/packages/hr-agent/src/middleware/validateSecret.ts
@@ -8,7 +8,18 @@ const HTTP = {
 const SECRET_HEADER = 'x-secret';
 const EXPECTED_SECRET = process.env.HRA_SECRET ?? 'hr-agent-secret';
 
+const SKIP_AUTH_PATHS = ['/v1/webhooks', '/v1/ca'];
+
+function shouldSkipAuth(path: string): boolean {
+  return SKIP_AUTH_PATHS.some((skipPath) => path.startsWith(skipPath));
+}
+
 function validateSecretMiddleware(req: Request, res: Response, next: NextFunction): void {
+  if (shouldSkipAuth(req.path)) {
+    next();
+    return;
+  }
+
   const clientSecret = req.headers[SECRET_HEADER] as string;
 
   if (!clientSecret || clientSecret !== EXPECTED_SECRET) {


### PR DESCRIPTION
## Summary
- 调整 `validateSecretMiddleware` 认证逻辑，跳过已有内置认证的路径
- `/v1/webhooks/*` 跳过通用认证（使用 GitHub webhook 签名验证）
- `/v1/ca/*` 跳过通用认证（使用 x-ca-secret 认证）
- 其他 `/v1/*` 路径仍需通用 x-secret 认证

## 认证路径说明

| 路径 | 通用认证 | 说明 |
|------|---------|------|
| `/health` | 不需要 | 在 routes 根目录 |
| `/v1/webhooks/*` | 跳过 | GitHub webhook 签名验证 |
| `/v1/ca/*` | 跳过 | x-ca-secret 认证 |
| `/ca/*` | 不适用 | 代理路径 |
| 其他 `/v1/*` | 需要 | 通用 x-secret 认证 |