### PR TITLE
feat: 修复任务分页、tags 过滤和 Dashboard 统计

### DIFF
--- a/packages/hr-agent-web/src/pages/TaskList/index.tsx
+++ b/packages/hr-agent-web/src/pages/TaskList/index.tsx
@@ -1,30 +1,52 @@
 import { useState, useMemo } from 'react';
 import { Card, Table, Space, Badge, Input, Select, Button } from 'antd';
+import type { TablePaginationConfig } from 'antd/es/table';
 import { ReloadOutlined, FilterOutlined } from '@ant-design/icons';
 import { useTasks } from '../../hooks/useTasks';
 import { useNavigate } from 'react-router-dom';
-import { TASK_TAG_LABELS, type Task, type TaskStatus } from '../../types/task';
+import { TASK_TAG_LABELS, type Task, type TaskStatus, type TaskQueryParams } from '../../types/task';
 import {
   getTaskListColumns,
-  calculateStatusCounts,
   isRunningStatus,
   STATUS_FILTER_OPTIONS,
   PRIORITY_FILTER_OPTIONS
 } from './columns';
 import './index.css';
 
+const DEFAULT_FILTER_TAGS = ['requires:ca', 'agent:coding', 'agent:review', 'agent:test'];
+
 const TAG_OPTIONS = Object.entries(TASK_TAG_LABELS).map(([value, label]) => ({
   value,
   label
 }));
 
+const DEFAULT_PAGE_SIZE = 10;
+
 export function TaskList() {
   const navigate = useNavigate();
-  const { data, isLoading, refetch } = useTasks();
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
   const [searchText, setSearchText] = useState('');
   const [statusFilter, setStatusFilter] = useState<TaskStatus | 'all'>('all');
   const [priorityFilter, setPriorityFilter] = useState<number | 'all'>('all');
-  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [filterTags, setFilterTags] = useState<string[]>(DEFAULT_FILTER_TAGS);
+
+  const queryParams: TaskQueryParams = useMemo(() => {
+    const params: TaskQueryParams = {
+      page,
+      pageSize,
+      tags: filterTags.length > 0 ? filterTags : undefined
+    };
+    if (statusFilter !== 'all') {
+      params.status = statusFilter;
+    }
+    if (priorityFilter !== 'all') {
+      params.priority = priorityFilter;
+    }
+    return params;
+  }, [page, pageSize, filterTags, statusFilter, priorityFilter]);
+
+  const { data, isLoading, refetch } = useTasks(queryParams);
 
   const tasks = useMemo(() => {
     return data?.tasks || [];
@@ -38,22 +60,25 @@ export function TaskList() {
         task.type.toLowerCase().includes(searchText.toLowerCase()) ||
         (task.issue?.issueTitle?.toLowerCase().includes(searchText.toLowerCase()) ?? false);
 
-      const matchesStatus = statusFilter === 'all' || task.status === statusFilter;
-      const matchesPriority = priorityFilter === 'all' || task.priority === priorityFilter;
-      const matchesTags =
-        filterTags.length === 0 || filterTags.some((tag) => task.tags?.includes(tag));
-
-      return matchesSearch && matchesStatus && matchesPriority && matchesTags;
+      return matchesSearch;
     });
-  }, [tasks, searchText, statusFilter, priorityFilter, filterTags]);
+  }, [tasks, searchText]);
 
   const columns = getTaskListColumns(navigate);
-  const statusCounts = calculateStatusCounts(tasks);
+
+  const handleTableChange = (pagination: TablePaginationConfig) => {
+    if (pagination.current) {
+      setPage(pagination.current);
+    }
+    if (pagination.pageSize) {
+      setPageSize(pagination.pageSize);
+    }
+  };
 
   return (
     <div className="task-list-page">
       <TaskListHeader
-        statusCounts={statusCounts}
+        total={data?.pagination?.total || 0}
         searchText={searchText}
         onSearchChange={setSearchText}
         statusFilter={statusFilter}
@@ -72,10 +97,14 @@ export function TaskList() {
           loading={isLoading}
           scroll={{ x: 1400 }}
           pagination={{
+            current: page,
+            pageSize,
+            total: data?.pagination?.total || 0,
             showSizeChanger: true,
             showTotal: (total) => `共 ${total} 条`,
             pageSizeOptions: ['10', '20', '50', '100']
           }}
+          onChange={handleTableChange}
           rowClassName={(record: Task) =>
             isRunningStatus(record.status) ? 'task-list-row-running' : ''
           }
@@ -86,13 +115,7 @@ export function TaskList() {
 }
 
 interface TaskListHeaderProps {
-  statusCounts: {
-    all: number;
-    queued: number;
-    running: number;
-    completed: number;
-    error: number;
-  };
+  total: number;
   searchText: string;
   onSearchChange: (value: string) => void;
   statusFilter: TaskStatus | 'all';
@@ -105,7 +128,7 @@ interface TaskListHeaderProps {
 }
 
 function TaskListHeader({
-  statusCounts,
+  total,
   searchText,
   onSearchChange,
   statusFilter,
@@ -121,10 +144,7 @@ function TaskListHeader({
       <div className="task-list-header-left">
         <h2>任务列表</h2>
         <Space size={16} className="task-list-stats">
-          <Badge status="default" text={`全部: ${statusCounts.all}`} />
-          <Badge status="processing" text={`运行中: ${statusCounts.running}`} />
-          <Badge status="success" text={`已完成: ${statusCounts.completed}`} />
-          <Badge status="error" text={`错误: ${statusCounts.error}`} />
+          <Badge status="default" text={`全部: ${total}`} />
         </Space>
       </div>
       <div className="task-list-header-right">

--- a/packages/hr-agent/src/routes/v1/tasks/index.get.test.ts
+++ b/packages/hr-agent/src/routes/v1/tasks/index.get.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockTasks = [
+  {
+    id: 1,
+    type: 'coding',
+    status: 'completed',
+    priority: 10,
+    tags: ['requires:ca', 'agent:coding'],
+    parentTaskId: null,
+    issueId: null,
+    prId: null,
+    caId: null,
+    metadata: {},
+    createdAt: 1739380000,
+    updatedAt: 1739380100,
+    completedAt: 1739380200,
+    deletedAt: -2,
+    subTasks: [],
+    issue: null,
+    pullRequest: null,
+    codingAgent: null
+  },
+  {
+    id: 2,
+    type: 'review',
+    status: 'running',
+    priority: 20,
+    tags: ['agent:review', 'agent:test'],
+    parentTaskId: null,
+    issueId: null,
+    prId: null,
+    caId: null,
+    metadata: {},
+    createdAt: 1739380300,
+    updatedAt: 1739380400,
+    completedAt: 0,
+    deletedAt: -2,
+    subTasks: [],
+    issue: null,
+    pullRequest: null,
+    codingAgent: null
+  },
+  {
+    id: 3,
+    type: 'test',
+    status: 'queued',
+    priority: 30,
+    tags: ['agent:test'],
+    parentTaskId: null,
+    issueId: null,
+    prId: null,
+    caId: null,
+    metadata: {},
+    createdAt: 1739380500,
+    updatedAt: 1739380600,
+    completedAt: 0,
+    deletedAt: -2,
+    subTasks: [],
+    issue: null,
+    pullRequest: null,
+    codingAgent: null
+  }
+];
+
+const mockTaskFindMany = vi.fn().mockResolvedValue(mockTasks);
+const mockTaskCount = vi.fn().mockResolvedValue(3);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    task: {
+      findMany: mockTaskFindMany,
+      count: mockTaskCount,
+      findFirst: vi.fn().mockResolvedValue(null),
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+      delete: vi.fn().mockResolvedValue({ id: 1 })
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+describe('Tasks GET Route Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('GET /v1/tasks', () => {
+    it('应该成功获取任务列表（无参数）', async () => {
+      mockTaskFindMany.mockResolvedValueOnce(mockTasks);
+      mockTaskCount.mockResolvedValueOnce(3);
+
+      const response = await request(app).get('/v1/tasks');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('tasks');
+      expect(response.body.data).toHaveProperty('pagination');
+      expect(response.body.data.pagination).toHaveProperty('page', 1);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 10);
+      expect(response.body.data.pagination).toHaveProperty('total', 3);
+    });
+
+    it('应该支持分页参数', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([mockTasks[0]]);
+      mockTaskCount.mockResolvedValueOnce(3);
+
+      const response = await request(app).get('/v1/tasks?page=2&pageSize=1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('page', 2);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 1);
+      expect(response.body.data.pagination).toHaveProperty('total', 3);
+      expect(response.body.data.pagination).toHaveProperty('totalPages', 3);
+    });
+
+    it('应该支持 tags 过滤（单个标签）', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([mockTasks[0]]);
+      mockTaskCount.mockResolvedValueOnce(1);
+
+      const response = await request(app).get('/v1/tasks?tags=requires:ca');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.tasks).toHaveLength(1);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tags: { hasSome: ['requires:ca'] }
+          })
+        })
+      );
+    });
+
+    it('应该支持 tags 过滤（多个标签）', async () => {
+      mockTaskFindMany.mockResolvedValueOnce(mockTasks.slice(0, 2));
+      mockTaskCount.mockResolvedValueOnce(2);
+
+      const response = await request(app).get(
+        '/v1/tasks?tags=requires:ca,agent:coding'
+      );
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tags: { hasSome: ['requires:ca', 'agent:coding'] }
+          })
+        })
+      );
+    });
+
+    it('应该支持 status 过滤', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([mockTasks[0]]);
+      mockTaskCount.mockResolvedValueOnce(1);
+
+      const response = await request(app).get('/v1/tasks?status=completed');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: 'completed'
+          })
+        })
+      );
+    });
+
+    it('应该支持 priority 过滤', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([mockTasks[2]]);
+      mockTaskCount.mockResolvedValueOnce(1);
+
+      const response = await request(app).get('/v1/tasks?priority=30');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            priority: 30
+          })
+        })
+      );
+    });
+
+    it('应该支持组合过滤条件', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([mockTasks[0]]);
+      mockTaskCount.mockResolvedValueOnce(1);
+
+      const response = await request(app).get(
+        '/v1/tasks?tags=requires:ca&status=completed&page=1&pageSize=10'
+      );
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tags: { hasSome: ['requires:ca'] },
+            status: 'completed'
+          }),
+          skip: 0,
+          take: 10
+        })
+      );
+    });
+
+    it('应该正确计算总页数', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(25);
+
+      const response = await request(app).get('/v1/tasks?pageSize=10');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('totalPages', 3);
+    });
+
+    it('应该排除软删除的任务', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            deletedAt: -2
+          })
+        })
+      );
+    });
+
+    it('应该排除子任务', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            parentTaskId: null
+          })
+        })
+      );
+    });
+
+    it('应该处理无效的分页参数（使用默认值）', async () => {
+      mockTaskFindMany.mockResolvedValueOnce(mockTasks);
+      mockTaskCount.mockResolvedValueOnce(3);
+
+      const response = await request(app).get('/v1/tasks?page=-1&pageSize=abc');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('page', 1);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 10);
+    });
+
+    it('应该支持 orderBy 参数', async () => {
+      mockTaskFindMany.mockResolvedValueOnce(mockTasks);
+      mockTaskCount.mockResolvedValueOnce(3);
+
+      const response = await request(app).get('/v1/tasks?orderBy=priority');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockTaskFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { priority: 'desc' }
+        })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 变更内容

- [x] 修复 TaskList 页面的分页功能，使用后端分页代替前端分页
- [x] 设置默认勾选 tags 为：需要CA、AI编码、AI审查、AI测试
- [x] 将 tags、status、priority 等过滤条件传递给后端 API
- [x] Dashboard 使用过滤后的任务数据，确保统计数据准确
- [x] 添加 tasks GET 路由的测试用例，覆盖分页、tags 过滤等功能

## 测试覆盖

- [x] 测试分页参数（page、pageSize）
- [x] 测试 tags 过滤（单个和多个标签）
- [x] 测试 status 和 priority 过滤
- [x] 测试组合过滤条件
- [x] 测试排序参数
- [x] 测试软删除和子任务排除逻辑

## 检查清单

- [x] 代码通过 typecheck
- [x] 代码通过 lint 检查
- [x] 所有测试用例通过
- [ ] CI 检查通过