### PR TITLE
test(hra): 提升测试覆盖率

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .DS_Store
 packages/*/node_modules/
 packages/*/dist/
+coverage/

--- a/packages/hr-agent/src/routes/health.test.ts
+++ b/packages/hr-agent/src/routes/health.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+
+describe('Health Route Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    app = express();
+    app.use(express.json());
+    const { default: healthRoute } = await import('./health.js');
+    app.get('/health', healthRoute);
+  });
+
+  describe('GET /health', () => {
+    it('应该返回状态为 ok', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('code', 200);
+      expect(response.body).toHaveProperty('message', 'success');
+      expect(response.body.data).toEqual({ status: 'ok' });
+    });
+
+    it('应该返回正确的响应结构', async () => {
+      const response = await request(app).get('/health');
+
+      expect(response.body).toHaveProperty('code');
+      expect(response.body).toHaveProperty('message');
+      expect(response.body).toHaveProperty('data');
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/ca/index.test.ts
+++ b/packages/hr-agent/src/routes/v1/ca/index.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockContainerInspect = vi.fn().mockResolvedValue({
+  Id: 'test-container-id',
+  Config: { Image: 'test-image' },
+  State: { Status: 'running' },
+  Created: '2024-01-01T00:00:00Z',
+  NetworkSettings: {
+    Ports: { '4096/tcp': [] }
+  }
+});
+
+const mockContainerStart = vi.fn().mockResolvedValue(undefined);
+const mockContainerRestart = vi.fn().mockResolvedValue(undefined);
+const mockContainerRemove = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('dockerode', () => {
+  const mockContainer = {
+    start: mockContainerStart,
+    restart: mockContainerRestart,
+    remove: mockContainerRemove,
+    inspect: mockContainerInspect
+  };
+
+  const mockDocker = {
+    getContainer: vi.fn().mockReturnValue(mockContainer),
+    listContainers: vi.fn().mockResolvedValue([
+      {
+        Id: 'container-1',
+        Names: ['/hra_test-ca-1'],
+        Image: 'test-image',
+        Status: 'running',
+        State: 'running',
+        Created: 1704067200
+      },
+      {
+        Id: 'container-2',
+        Names: ['/other-container'],
+        Image: 'other-image',
+        Status: 'exited',
+        State: 'exited',
+        Created: 1704067200
+      }
+    ])
+  };
+
+  class MockDocker {
+    constructor() {
+      return mockDocker;
+    }
+  }
+
+  return {
+    default: MockDocker
+  };
+});
+
+vi.mock('../../../utils/secretManager.js', () => ({
+  getDockerCASecret: vi.fn().mockReturnValue('test-secret'),
+  getGitHubWebhookSecret: vi.fn().mockReturnValue('test-webhook-secret'),
+  getGitHubToken: vi.fn().mockReturnValue('test-token'),
+  getGitHubOwner: vi.fn().mockReturnValue('test-owner'),
+  getGitHubRepo: vi.fn().mockReturnValue('test-repo'),
+  getSecret: vi.fn().mockReturnValue('test-secret')
+}));
+
+const mockCodingAgentFindFirst = vi.fn().mockResolvedValue(null);
+const mockCodingAgentUpdate = vi.fn().mockResolvedValue({ id: 1 });
+const mockTaskManagerRun = vi.fn().mockResolvedValue(1);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    codingAgent: {
+      findFirst: mockCodingAgentFindFirst,
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: mockCodingAgentUpdate,
+      delete: vi.fn().mockResolvedValue({ id: 1 }),
+      findMany: vi.fn().mockResolvedValue([])
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+describe('CA Routes Tests', () => {
+  let app: Express;
+  const TEST_SECRET = 'test-secret';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockContainerInspect.mockResolvedValue({
+      Id: 'test-container-id',
+      Config: { Image: 'test-image' },
+      State: { Status: 'running' },
+      Created: '2024-01-01T00:00:00Z',
+      NetworkSettings: {
+        Ports: { '4096/tcp': [] }
+      }
+    });
+    mockCodingAgentFindFirst.mockResolvedValue(null);
+
+    global.taskManager = {
+      run: mockTaskManagerRun,
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue({ caPool: [] })
+    } as never;
+
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.taskManager = undefined as never;
+  });
+
+  describe('GET /v1/ca', () => {
+    it('应该在未授权时返回 401', async () => {
+      const response = await request(app).get('/v1/ca');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.UNAUTHORIZED);
+    });
+
+    it('应该成功返回 CA 容器列表', async () => {
+      const response = await request(app).get('/v1/ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('total');
+      expect(response.body.data).toHaveProperty('containers');
+      expect(Array.isArray(response.body.data.containers)).toBe(true);
+    });
+
+    it('应该只返回 hra_ 前缀的容器', async () => {
+      const response = await request(app).get('/v1/ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.containers).toHaveLength(1);
+      expect(response.body.data.containers[0].name).toBe('hra_test-ca-1');
+    });
+  });
+
+  describe('GET /v1/ca/:name', () => {
+    it('应该在未授权时返回 401', async () => {
+      const response = await request(app).get('/v1/ca/test-ca');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.UNAUTHORIZED);
+    });
+
+    it('应该成功返回容器信息', async () => {
+      const response = await request(app).get('/v1/ca/test-ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('containerId', 'test-container-id');
+      expect(response.body.data).toHaveProperty('status', 'running');
+    });
+
+    it('应该在容器不存在时返回 404', async () => {
+      mockContainerInspect.mockRejectedValueOnce(new Error('Container not found'));
+
+      const response = await request(app)
+        .get('/v1/ca/non-existent')
+        .set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+  });
+
+  describe('PUT /v1/ca/:name', () => {
+    it('应该在未授权时返回 401', async () => {
+      const response = await request(app).put('/v1/ca/test-ca').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.UNAUTHORIZED);
+    });
+
+    it('应该成功更新容器（不重启）', async () => {
+      const response = await request(app)
+        .put('/v1/ca/test-ca')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('message', 'Docker container updated successfully');
+    });
+
+    it('应该成功重启容器', async () => {
+      const response = await request(app)
+        .put('/v1/ca/test-ca')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({ restart: true });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(mockContainerRestart).toHaveBeenCalled();
+    });
+
+    it('应该在容器不存在时返回 404', async () => {
+      mockContainerInspect.mockRejectedValueOnce(new Error('Container not found'));
+
+      const response = await request(app)
+        .put('/v1/ca/non-existent')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+  });
+
+  describe('DELETE /v1/ca/:name', () => {
+    it('应该在未授权时返回 401', async () => {
+      const response = await request(app).delete('/v1/ca/test-ca');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.UNAUTHORIZED);
+    });
+
+    it('应该在 CA 记录不存在时返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).delete('/v1/ca/test-ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功删除 CA', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce({
+        id: 1,
+        caName: 'test-ca',
+        status: 'running',
+        containerId: 'container-123'
+      });
+
+      const response = await request(app).delete('/v1/ca/test-ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('status', 'pending_delete');
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+
+    it('应该在 CA 已在删除队列时返回 400', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce({
+        id: 1,
+        caName: 'test-ca',
+        status: 'pending_delete',
+        containerId: 'container-123'
+      });
+
+      const response = await request(app).delete('/v1/ca/test-ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('already pending deletion');
+    });
+
+    it('应该在 TaskManager 未初始化时返回 500', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce({
+        id: 1,
+        caName: 'test-ca',
+        status: 'running',
+        containerId: 'container-123'
+      });
+      global.taskManager = undefined as never;
+
+      const response = await request(app).delete('/v1/ca/test-ca').set('x-ca-secret', TEST_SECRET);
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+      expect(response.body.message).toContain('TaskManager');
+    });
+  });
+
+  describe('POST /v1/ca/add', () => {
+    it('应该在未授权时返回 401', async () => {
+      const response = await request(app).post('/v1/ca/add').send({ name: 'test-ca' });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.UNAUTHORIZED);
+    });
+
+    it('应该在缺少 name 和 issueId 时返回 400', async () => {
+      const response = await request(app)
+        .post('/v1/ca/add')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('name or issueId is required');
+    });
+
+    it('应该成功创建 CA（使用 name）', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app)
+        .post('/v1/ca/add')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({ name: 'test-ca' });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('status', 'pending_create');
+      expect(response.body.data.name).toMatch(/^hra_test-ca$/);
+    });
+
+    it('应该成功创建 CA（使用 issueId）', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app)
+        .post('/v1/ca/add')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({ issueId: 123 });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data.name).toBe('hra_123');
+    });
+
+    it('应该在 CA 名称已存在时返回 400', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce({
+        id: 1,
+        caName: 'hra_test-ca'
+      });
+
+      const response = await request(app)
+        .post('/v1/ca/add')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({ name: 'test-ca' });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('already exists');
+    });
+
+    it('应该拒绝无效的容器名称', async () => {
+      const response = await request(app)
+        .post('/v1/ca/add')
+        .set('x-ca-secret', TEST_SECRET)
+        .send({ name: 'invalid@name!' });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('valid Docker container name');
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/cas/[id]/operations.test.ts
+++ b/packages/hr-agent/src/routes/v1/cas/[id]/operations.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockCodingAgentFindFirst = vi.fn().mockResolvedValue(null);
+const mockCodingAgentUpdate = vi.fn().mockResolvedValue({ id: 1 });
+const mockTaskManagerRun = vi.fn().mockResolvedValue(1);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    codingAgent: {
+      findFirst: mockCodingAgentFindFirst,
+      findUnique: vi.fn().mockResolvedValue(null),
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      update: mockCodingAgentUpdate,
+      delete: vi.fn().mockResolvedValue({ id: 1 }),
+      findMany: vi.fn().mockResolvedValue([])
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+vi.mock('../../../../utils/secretManager.js', () => ({
+  getDockerCASecret: vi.fn().mockReturnValue('test-secret'),
+  getGitHubWebhookSecret: vi.fn().mockReturnValue('test-webhook-secret'),
+  getGitHubToken: vi.fn().mockReturnValue('test-token'),
+  getGitHubOwner: vi.fn().mockReturnValue('test-owner'),
+  getGitHubRepo: vi.fn().mockReturnValue('test-repo'),
+  getSecret: vi.fn().mockReturnValue('test-secret')
+}));
+
+vi.mock('dockerode', () => {
+  const mockContainer = {
+    start: vi.fn().mockResolvedValue(undefined),
+    restart: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    inspect: vi.fn().mockResolvedValue({
+      Id: 'test-container-id',
+      State: { Status: 'running' }
+    })
+  };
+
+  class MockDocker {
+    constructor() {
+      return {
+        getContainer: vi.fn().mockReturnValue(mockContainer),
+        listContainers: vi.fn().mockResolvedValue([])
+      };
+    }
+  }
+
+  return {
+    default: MockDocker
+  };
+});
+
+describe('CAS Operations Routes Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockCodingAgentFindFirst.mockResolvedValue({
+      id: 1,
+      caName: 'test-ca',
+      containerId: 'container-123',
+      status: 'running',
+      createdAt: 0,
+      updatedAt: 0
+    });
+
+    global.taskManager = {
+      run: mockTaskManagerRun,
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue({ caPool: [] })
+    } as never;
+
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.taskManager = undefined as never;
+  });
+
+  describe('POST /v1/cas/:id/restart', () => {
+    it('应该在 ID 无效时返回 400', async () => {
+      const response = await request(app).post('/v1/cas/invalid/restart');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('Invalid ID');
+    });
+
+    it('应该在 CA 不存在时返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).post('/v1/cas/999/restart');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+      expect(response.body.message).toContain('not found');
+    });
+
+    it('应该在 CA 没有关联容器时返回 400', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce({
+        id: 1,
+        caName: 'test-ca',
+        containerId: null,
+        status: 'pending'
+      });
+
+      const response = await request(app).post('/v1/cas/1/restart');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('No container');
+    });
+
+    it('应该成功创建重启任务', async () => {
+      const response = await request(app).post('/v1/cas/1/restart');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('status', 'pending_restart');
+      expect(response.body.data).toHaveProperty('taskId');
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+
+    it('应该在 TaskManager 未初始化时返回 500', async () => {
+      global.taskManager = undefined as never;
+
+      const response = await request(app).post('/v1/cas/1/restart');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  describe('POST /v1/cas/:id/start', () => {
+    it('应该在 ID 无效时返回 400', async () => {
+      const response = await request(app).post('/v1/cas/invalid/start');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+    });
+
+    it('应该在 CA 不存在时返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).post('/v1/cas/999/start');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功创建启动任务', async () => {
+      const response = await request(app).post('/v1/cas/1/start');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('status', 'pending_start');
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /v1/cas/:id/stop', () => {
+    it('应该在 ID 无效时返回 400', async () => {
+      const response = await request(app).post('/v1/cas/invalid/stop');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+    });
+
+    it('应该在 CA 不存在时返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).post('/v1/cas/999/stop');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功创建停止任务', async () => {
+      const response = await request(app).post('/v1/cas/1/stop');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('status', 'pending_stop');
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/config.get.test.ts
+++ b/packages/hr-agent/src/routes/v1/config.get.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+
+vi.mock('../../config/taskConfig.js', () => ({
+  TASK_CONFIG: {
+    CA_NAME_PREFIX: 'test-ca-prefix'
+  }
+}));
+
+describe('Config Route Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    const { default: configRoute } = await import('./config.get.js');
+    app.get('/v1/config', configRoute);
+  });
+
+  describe('GET /v1/config', () => {
+    it('应该返回 CA 名称前缀配置', async () => {
+      const response = await request(app).get('/v1/config');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty('code', 200);
+      expect(response.body).toHaveProperty('message', 'success');
+      expect(response.body.data).toHaveProperty('caNamePrefix', 'test-ca-prefix');
+    });
+
+    it('应该返回正确的响应结构', async () => {
+      const response = await request(app).get('/v1/config');
+
+      expect(response.body).toHaveProperty('code');
+      expect(response.body).toHaveProperty('message');
+      expect(response.body).toHaveProperty('data');
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/issues/[issueId]/prs.test.ts
+++ b/packages/hr-agent/src/routes/v1/issues/[issueId]/prs.test.ts
@@ -55,7 +55,7 @@ describe('Issue PR Relation API', () => {
     (getPrismaClient as unknown as ReturnType<typeof vi.fn>).mockReturnValue(mockPrismaClient);
   });
 
-  describe('GET /api/v1/issues/:issueId/prs', () => {
+  describe('GET /v1/issues/:issueId/prs', () => {
     it('should return all PRs for a valid issue', async () => {
       const mockPrs = [
         { id: 1, prId: 101, prTitle: 'PR 1' },
@@ -76,9 +76,9 @@ describe('Issue PR Relation API', () => {
       mockPrismaClient.issuePR.findMany.mockResolvedValue([mockIssuePr1, mockIssuePr2]);
 
       const { default: route } = await import('./prs.get.js');
-      app.get('/api/v1/issues/:issueId/prs', route);
+      app.get('/v1/issues/:issueId/prs', route);
 
-      const response = await request(app).get('/api/v1/issues/1/prs');
+      const response = await request(app).get('/v1/issues/1/prs');
 
       expect(response.body.code).toBe(HTTP_STATUS.OK);
       expect(response.body.data).toHaveLength(2);
@@ -88,9 +88,9 @@ describe('Issue PR Relation API', () => {
 
     it('should return 400 for invalid issue ID', async () => {
       const { default: route } = await import('./prs.get.js');
-      app.get('/api/v1/issues/:issueId/prs', route);
+      app.get('/v1/issues/:issueId/prs', route);
 
-      const response = await request(app).get('/api/v1/issues/invalid/prs');
+      const response = await request(app).get('/v1/issues/invalid/prs');
 
       expect(response.body.code).toBe(HTTP_STATUS.BAD_REQUEST);
       expect(response.body.message).toContain('Invalid issue ID');
@@ -100,16 +100,16 @@ describe('Issue PR Relation API', () => {
       mockPrismaClient.issuePR.findMany.mockResolvedValue([]);
 
       const { default: route } = await import('./prs.get.js');
-      app.get('/api/v1/issues/:issueId/prs', route);
+      app.get('/v1/issues/:issueId/prs', route);
 
-      const response = await request(app).get('/api/v1/issues/1/prs');
+      const response = await request(app).get('/v1/issues/1/prs');
 
       expect(response.body.code).toBe(HTTP_STATUS.OK);
       expect(response.body.data).toEqual([]);
     });
   });
 
-  describe('GET /api/v1/issues/:issueId/latest-pr', () => {
+  describe('GET /v1/issues/:issueId/latest-pr', () => {
     it('should return the latest PR for a valid issue', async () => {
       const mockPr = { id: 1, prId: 101, prTitle: 'Latest PR' };
 
@@ -120,9 +120,9 @@ describe('Issue PR Relation API', () => {
       });
 
       const { default: route } = await import('./latest-pr.get.js');
-      app.get('/api/v1/issues/:issueId/latest-pr', route);
+      app.get('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app).get('/api/v1/issues/1/latest-pr');
+      const response = await request(app).get('/v1/issues/1/latest-pr');
 
       expect(response.body.code).toBe(HTTP_STATUS.OK);
       expect(response.body.data).not.toBeNull();
@@ -133,16 +133,16 @@ describe('Issue PR Relation API', () => {
       mockPrismaClient.issuePR.findFirst.mockResolvedValue(null);
 
       const { default: route } = await import('./latest-pr.get.js');
-      app.get('/api/v1/issues/:issueId/latest-pr', route);
+      app.get('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app).get('/api/v1/issues/1/latest-pr');
+      const response = await request(app).get('/v1/issues/1/latest-pr');
 
       expect(response.body.code).toBe(HTTP_STATUS.NOT_FOUND);
       expect(response.body.message).toContain('No PR found');
     });
   });
 
-  describe('PUT /api/v1/issues/:issueId/latest-pr', () => {
+  describe('PUT /v1/issues/:issueId/latest-pr', () => {
     it('should associate a PR with an issue', async () => {
       mockPrismaClient.issue.findFirst.mockResolvedValue({ id: 1, deletedAt: -2 });
       mockPrismaClient.pullRequest.findFirst.mockResolvedValue({ id: 2, deletedAt: -2 });
@@ -155,9 +155,9 @@ describe('Issue PR Relation API', () => {
       });
 
       const { default: route } = await import('./latest-pr.put.js');
-      app.put('/api/v1/issues/:issueId/latest-pr', route);
+      app.put('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app).put('/api/v1/issues/1/latest-pr').send({ prId: 2 });
+      const response = await request(app).put('/v1/issues/1/latest-pr').send({ prId: 2 });
 
       expect(response.body.code).toBe(HTTP_STATUS.CREATED);
       expect(response.body.message).toContain('PR associated with issue successfully');
@@ -165,9 +165,9 @@ describe('Issue PR Relation API', () => {
 
     it('should return 400 for invalid issue ID', async () => {
       const { default: route } = await import('./latest-pr.put.js');
-      app.put('/api/v1/issues/:issueId/latest-pr', route);
+      app.put('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app).put('/api/v1/issues/invalid/latest-pr').send({ prId: 2 });
+      const response = await request(app).put('/v1/issues/invalid/latest-pr').send({ prId: 2 });
 
       expect(response.body.code).toBe(HTTP_STATUS.BAD_REQUEST);
       expect(response.body.message).toContain('Invalid issue ID');
@@ -175,11 +175,9 @@ describe('Issue PR Relation API', () => {
 
     it('should return 400 for invalid PR ID', async () => {
       const { default: route } = await import('./latest-pr.put.js');
-      app.put('/api/v1/issues/:issueId/latest-pr', route);
+      app.put('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app)
-        .put('/api/v1/issues/1/latest-pr')
-        .send({ prId: 'invalid' });
+      const response = await request(app).put('/v1/issues/1/latest-pr').send({ prId: 'invalid' });
 
       expect(response.body.code).toBe(HTTP_STATUS.BAD_REQUEST);
       expect(response.body.message).toContain('Invalid PR ID');
@@ -196,16 +194,16 @@ describe('Issue PR Relation API', () => {
       });
 
       const { default: route } = await import('./latest-pr.put.js');
-      app.put('/api/v1/issues/:issueId/latest-pr', route);
+      app.put('/v1/issues/:issueId/latest-pr', route);
 
-      const response = await request(app).put('/api/v1/issues/1/latest-pr').send({ prId: 2 });
+      const response = await request(app).put('/v1/issues/1/latest-pr').send({ prId: 2 });
 
       expect(response.body.code).toBe(HTTP_STATUS.OK);
       expect(response.body.message).toContain('PR already associated');
     });
   });
 
-  describe('GET /api/v1/prs/:prId/issue', () => {
+  describe('GET /v1/prs/:prId/issue', () => {
     it('should return the associated issue for a valid PR', async () => {
       const mockIssue = { id: 1, issueId: 101, issueTitle: 'Test Issue' };
 
@@ -216,9 +214,9 @@ describe('Issue PR Relation API', () => {
       });
 
       const { default: route } = await import('../../prs/[prId]/issue.get.js');
-      app.get('/api/v1/prs/:prId/issue', route);
+      app.get('/v1/prs/:prId/issue', route);
 
-      const response = await request(app).get('/api/v1/prs/1/issue');
+      const response = await request(app).get('/v1/prs/1/issue');
 
       expect(response.body.code).toBe(HTTP_STATUS.OK);
       expect(response.body.data).not.toBeNull();
@@ -229,9 +227,9 @@ describe('Issue PR Relation API', () => {
       mockPrismaClient.issuePR.findFirst.mockResolvedValue(null);
 
       const { default: route } = await import('../../prs/[prId]/issue.get.js');
-      app.get('/api/v1/prs/:prId/issue', route);
+      app.get('/v1/prs/:prId/issue', route);
 
-      const response = await request(app).get('/api/v1/prs/1/issue');
+      const response = await request(app).get('/v1/prs/1/issue');
 
       expect(response.body.code).toBe(HTTP_STATUS.NOT_FOUND);
       expect(response.body.message).toContain('No issue found');
@@ -239,9 +237,9 @@ describe('Issue PR Relation API', () => {
 
     it('should return 400 for invalid PR ID', async () => {
       const { default: route } = await import('../../prs/[prId]/issue.get.js');
-      app.get('/api/v1/prs/:prId/issue', route);
+      app.get('/v1/prs/:prId/issue', route);
 
-      const response = await request(app).get('/api/v1/prs/invalid/issue');
+      const response = await request(app).get('/v1/prs/invalid/issue');
 
       expect(response.body.code).toBe(HTTP_STATUS.BAD_REQUEST);
       expect(response.body.message).toContain('Invalid PR ID');

--- a/packages/hr-agent/src/routes/v1/issues/index.test.ts
+++ b/packages/hr-agent/src/routes/v1/issues/index.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockIssueFindMany = vi.fn().mockResolvedValue([]);
+const mockIssueFindFirst = vi.fn().mockResolvedValue(null);
+const mockIssueFindUnique = vi.fn().mockResolvedValue(null);
+const mockIssueCreate = vi.fn().mockResolvedValue({ id: 1 });
+const mockIssueUpdate = vi.fn().mockResolvedValue({ id: 1 });
+const mockIssueDelete = vi.fn().mockResolvedValue({ id: 1 });
+const mockIssueCount = vi.fn().mockResolvedValue(0);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    issue: {
+      findMany: mockIssueFindMany,
+      findFirst: mockIssueFindFirst,
+      findUnique: mockIssueFindUnique,
+      create: mockIssueCreate,
+      update: mockIssueUpdate,
+      delete: mockIssueDelete,
+      count: mockIssueCount
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+vi.mock('../../../utils/secretManager.js', () => ({
+  getDockerCASecret: vi.fn().mockReturnValue('test-secret'),
+  getGitHubWebhookSecret: vi.fn().mockReturnValue('test-webhook-secret'),
+  getGitHubToken: vi.fn().mockReturnValue('test-token'),
+  getGitHubOwner: vi.fn().mockReturnValue('test-owner'),
+  getGitHubRepo: vi.fn().mockReturnValue('test-repo'),
+  getSecret: vi.fn().mockReturnValue('test-secret')
+}));
+
+vi.mock('dockerode', () => {
+  class MockDocker {
+    constructor() {
+      return {
+        getContainer: vi.fn().mockReturnValue({
+          inspect: vi.fn().mockResolvedValue({ Id: 'test', State: { Status: 'running' } })
+        }),
+        listContainers: vi.fn().mockResolvedValue([])
+      };
+    }
+  }
+  return { default: MockDocker };
+});
+
+describe('Issues Routes Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    global.taskManager = {
+      run: vi.fn().mockResolvedValue(1),
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue({ caPool: [] })
+    } as never;
+
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.taskManager = undefined as never;
+  });
+
+  describe('GET /v1/issues', () => {
+    it('应该成功获取 Issue 列表', async () => {
+      mockIssueFindMany.mockResolvedValueOnce([]);
+      mockIssueCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/issues');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('issues');
+      expect(response.body.data).toHaveProperty('pagination');
+    });
+
+    it('应该支持分页参数', async () => {
+      mockIssueFindMany.mockResolvedValueOnce([]);
+      mockIssueCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/issues?page=2&pageSize=20');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('page', 2);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 20);
+    });
+
+    it('应该支持排序参数', async () => {
+      mockIssueFindMany.mockResolvedValueOnce([]);
+      mockIssueCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/issues?orderBy=issueTitle');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+    });
+  });
+
+  describe('POST /v1/issues', () => {
+    it('应该在缺少必填字段时返回 400', async () => {
+      const response = await request(app).post('/v1/issues').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('issueId, issueUrl, and issueTitle are required');
+    });
+
+    it('应该成功创建 Issue', async () => {
+      mockIssueFindUnique.mockResolvedValueOnce(null);
+      mockIssueCreate.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123,
+        issueUrl: 'https://github.com/test/repo/issues/123',
+        issueTitle: 'Test Issue'
+      });
+
+      const response = await request(app).post('/v1/issues').send({
+        issueId: 123,
+        issueUrl: 'https://github.com/test/repo/issues/123',
+        issueTitle: 'Test Issue'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('issueId', 123);
+    });
+
+    it('应该在 Issue 已存在时返回 409', async () => {
+      mockIssueFindUnique.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123
+      });
+
+      const response = await request(app).post('/v1/issues').send({
+        issueId: 123,
+        issueUrl: 'https://github.com/test/repo/issues/123',
+        issueTitle: 'Test Issue'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.CONFLICT);
+      expect(response.body.message).toContain('already exists');
+    });
+  });
+
+  describe('GET /v1/issues/:id', () => {
+    it('应该在 Issue 不存在时返回 404', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).get('/v1/issues/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功获取单个 Issue', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123,
+        issueUrl: 'https://github.com/test/repo/issues/123',
+        issueTitle: 'Test Issue'
+      });
+
+      const response = await request(app).get('/v1/issues/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('id', 1);
+    });
+  });
+
+  describe('PUT /v1/issues/:id', () => {
+    it('应该在 Issue 不存在时返回 404', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).put('/v1/issues/999').send({
+        issueTitle: 'Updated Title'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功更新 Issue', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123,
+        issueTitle: 'Test Issue'
+      });
+      mockIssueUpdate.mockResolvedValueOnce({
+        id: 1,
+        issueTitle: 'Updated Title'
+      });
+
+      const response = await request(app).put('/v1/issues/1').send({
+        issueTitle: 'Updated Title'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+
+  describe('DELETE /v1/issues/:id', () => {
+    it('应该在 Issue 不存在时返回 404', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).delete('/v1/issues/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功删除 Issue', async () => {
+      mockIssueFindFirst.mockResolvedValueOnce({
+        id: 1,
+        issueId: 123
+      });
+      mockIssueUpdate.mockResolvedValueOnce({ id: 1 });
+
+      const response = await request(app).delete('/v1/issues/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/prs/index.test.ts
+++ b/packages/hr-agent/src/routes/v1/prs/index.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockPRFindMany = vi.fn().mockResolvedValue([]);
+const mockPRFindFirst = vi.fn().mockResolvedValue(null);
+const mockPRFindUnique = vi.fn().mockResolvedValue(null);
+const mockPRCreate = vi.fn().mockResolvedValue({ id: 1 });
+const mockPRUpdate = vi.fn().mockResolvedValue({ id: 1 });
+const mockPRCount = vi.fn().mockResolvedValue(0);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    pullRequest: {
+      findMany: mockPRFindMany,
+      findFirst: mockPRFindFirst,
+      findUnique: mockPRFindUnique,
+      create: mockPRCreate,
+      update: mockPRUpdate,
+      delete: vi.fn().mockResolvedValue({ id: 1 }),
+      count: mockPRCount
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+vi.mock('../../../utils/secretManager.js', () => ({
+  getDockerCASecret: vi.fn().mockReturnValue('test-secret'),
+  getGitHubWebhookSecret: vi.fn().mockReturnValue('test-webhook-secret'),
+  getGitHubToken: vi.fn().mockReturnValue('test-token'),
+  getGitHubOwner: vi.fn().mockReturnValue('test-owner'),
+  getGitHubRepo: vi.fn().mockReturnValue('test-repo'),
+  getSecret: vi.fn().mockReturnValue('test-secret')
+}));
+
+vi.mock('dockerode', () => {
+  class MockDocker {
+    constructor() {
+      return {
+        getContainer: vi.fn().mockReturnValue({
+          inspect: vi.fn().mockResolvedValue({ Id: 'test', State: { Status: 'running' } })
+        }),
+        listContainers: vi.fn().mockResolvedValue([])
+      };
+    }
+  }
+  return { default: MockDocker };
+});
+
+describe('PRs Routes Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    global.taskManager = {
+      run: vi.fn().mockResolvedValue(1),
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue({ caPool: [] })
+    } as never;
+
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.taskManager = undefined as never;
+  });
+
+  describe('GET /v1/prs', () => {
+    it('应该成功获取 PR 列表', async () => {
+      mockPRFindMany.mockResolvedValueOnce([]);
+      mockPRCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/prs');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('prs');
+      expect(response.body.data).toHaveProperty('pagination');
+    });
+
+    it('应该支持分页参数', async () => {
+      mockPRFindMany.mockResolvedValueOnce([]);
+      mockPRCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/prs?page=2&pageSize=20');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('page', 2);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 20);
+    });
+
+    it('应该支持 issueId 过滤', async () => {
+      mockPRFindMany.mockResolvedValueOnce([]);
+      mockPRCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/prs?issueId=123');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+    });
+  });
+
+  describe('POST /v1/prs', () => {
+    it('应该在缺少必填字段时返回 400', async () => {
+      const response = await request(app).post('/v1/prs').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('prId, prTitle, and prUrl are required');
+    });
+
+    it('应该成功创建 PR', async () => {
+      mockPRFindUnique.mockResolvedValueOnce(null);
+      mockPRCreate.mockResolvedValueOnce({
+        id: 1,
+        prId: 456,
+        prTitle: 'Test PR',
+        prUrl: 'https://github.com/test/repo/pull/456'
+      });
+
+      const response = await request(app).post('/v1/prs').send({
+        prId: 456,
+        prTitle: 'Test PR',
+        prUrl: 'https://github.com/test/repo/pull/456'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('prId', 456);
+    });
+
+    it('应该在 PR 已存在时返回 409', async () => {
+      mockPRFindUnique.mockResolvedValueOnce({
+        id: 1,
+        prId: 456
+      });
+
+      const response = await request(app).post('/v1/prs').send({
+        prId: 456,
+        prTitle: 'Test PR',
+        prUrl: 'https://github.com/test/repo/pull/456'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.CONFLICT);
+      expect(response.body.message).toContain('already exists');
+    });
+  });
+
+  describe('GET /v1/prs/:id', () => {
+    it('应该在 PR 不存在时返回 404', async () => {
+      mockPRFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).get('/v1/prs/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功获取单个 PR', async () => {
+      mockPRFindFirst.mockResolvedValueOnce({
+        id: 1,
+        prId: 456,
+        prTitle: 'Test PR'
+      });
+
+      const response = await request(app).get('/v1/prs/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('id', 1);
+    });
+  });
+
+  describe('PUT /v1/prs/:id', () => {
+    it('应该在 PR 不存在时返回 404', async () => {
+      mockPRFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).put('/v1/prs/999').send({
+        prTitle: 'Updated Title'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功更新 PR', async () => {
+      mockPRFindFirst.mockResolvedValueOnce({
+        id: 1,
+        prId: 456,
+        prTitle: 'Test PR'
+      });
+      mockPRUpdate.mockResolvedValueOnce({
+        id: 1,
+        prTitle: 'Updated Title'
+      });
+
+      const response = await request(app).put('/v1/prs/1').send({
+        prTitle: 'Updated Title'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+
+  describe('DELETE /v1/prs/:id', () => {
+    it('应该在 PR 不存在时返回 404', async () => {
+      mockPRFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).delete('/v1/prs/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功删除 PR', async () => {
+      mockPRFindFirst.mockResolvedValueOnce({
+        id: 1,
+        prId: 456
+      });
+      mockPRUpdate.mockResolvedValueOnce({ id: 1 });
+
+      const response = await request(app).delete('/v1/prs/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+});

--- a/packages/hr-agent/src/routes/v1/tasks/index.test.ts
+++ b/packages/hr-agent/src/routes/v1/tasks/index.test.ts
@@ -1,0 +1,376 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const HTTP_STATUS = {
+  OK: 200,
+  BAD_REQUEST: 400,
+  NOT_FOUND: 404,
+  INTERNAL_SERVER_ERROR: 500
+} as const;
+
+const mockTaskFindMany = vi.fn().mockResolvedValue([]);
+const mockTaskFindFirst = vi.fn().mockResolvedValue(null);
+const mockTaskFindUnique = vi.fn().mockResolvedValue(null);
+const mockTaskCreate = vi.fn().mockResolvedValue({ id: 1 });
+const mockTaskUpdate = vi.fn().mockResolvedValue({ id: 1 });
+const mockTaskCount = vi.fn().mockResolvedValue(0);
+const mockTaskManagerRun = vi.fn().mockResolvedValue(1);
+const mockTaskManagerRunExisting = vi.fn().mockResolvedValue(1);
+const mockTaskManagerApiRun = vi.fn().mockResolvedValue(1);
+
+vi.mock('@prisma/client', () => {
+  const mockPrismaClient = {
+    task: {
+      findMany: mockTaskFindMany,
+      findFirst: mockTaskFindFirst,
+      findUnique: mockTaskFindUnique,
+      create: mockTaskCreate,
+      update: mockTaskUpdate,
+      delete: vi.fn().mockResolvedValue({ id: 1 }),
+      count: mockTaskCount
+    },
+    $disconnect: vi.fn().mockResolvedValue(undefined)
+  };
+
+  class MockPrismaClient {
+    constructor() {
+      return mockPrismaClient;
+    }
+  }
+
+  return {
+    PrismaClient: MockPrismaClient
+  };
+});
+
+vi.mock('../../../utils/secretManager.js', () => ({
+  getDockerCASecret: vi.fn().mockReturnValue('test-secret'),
+  getGitHubWebhookSecret: vi.fn().mockReturnValue('test-webhook-secret'),
+  getGitHubToken: vi.fn().mockReturnValue('test-token'),
+  getGitHubOwner: vi.fn().mockReturnValue('test-owner'),
+  getGitHubRepo: vi.fn().mockReturnValue('test-repo'),
+  getSecret: vi.fn().mockReturnValue('test-secret')
+}));
+
+vi.mock('dockerode', () => {
+  class MockDocker {
+    constructor() {
+      return {
+        getContainer: vi.fn().mockReturnValue({
+          inspect: vi.fn().mockResolvedValue({ Id: 'test', State: { Status: 'running' } })
+        }),
+        listContainers: vi.fn().mockResolvedValue([])
+      };
+    }
+  }
+  return { default: MockDocker };
+});
+
+describe('Tasks Routes Tests', () => {
+  let app: Express;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    global.taskManager = {
+      run: mockTaskManagerRun,
+      runExisting: mockTaskManagerRunExisting,
+      apiRun: mockTaskManagerApiRun,
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue({ caPool: [] })
+    } as never;
+
+    app = express();
+    app.use(express.json());
+    const { default: autoLoadRoutes } = await import('../../../middleware/autoLoadRoutes.js');
+    const ROUTES_DIR = join(__dirname, '..', '..', '..', 'routes');
+    await autoLoadRoutes(app, ROUTES_DIR);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    global.taskManager = undefined as never;
+  });
+
+  describe('GET /v1/tasks', () => {
+    it('应该成功获取任务列表', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('tasks');
+      expect(response.body.data).toHaveProperty('pagination');
+    });
+
+    it('应该支持分页参数', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks?page=2&pageSize=20');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body.data.pagination).toHaveProperty('page', 2);
+      expect(response.body.data.pagination).toHaveProperty('pageSize', 20);
+    });
+
+    it('应该支持状态过滤', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks?status=pending');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+    });
+
+    it('应该支持 tags 过滤', async () => {
+      mockTaskFindMany.mockResolvedValueOnce([]);
+      mockTaskCount.mockResolvedValueOnce(0);
+
+      const response = await request(app).get('/v1/tasks?tags=test,example');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+    });
+  });
+
+  describe('POST /v1/tasks', () => {
+    it('应该在缺少 type 时返回 400', async () => {
+      const response = await request(app).post('/v1/tasks').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('type is required');
+    });
+
+    it('应该在 TaskManager 未初始化时返回 500', async () => {
+      global.taskManager = undefined as never;
+
+      const response = await request(app).post('/v1/tasks').send({
+        type: 'test_task'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    });
+
+    it('应该成功创建任务', async () => {
+      mockTaskFindUnique.mockResolvedValueOnce({ id: 1, type: 'test_task' });
+
+      const response = await request(app).post('/v1/tasks').send({
+        type: 'test_task',
+        priority: 10
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /v1/tasks/execute', () => {
+    it('应该在没有任何参数时返回 400', async () => {
+      const response = await request(app).post('/v1/tasks/execute').send({});
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('taskName、uri 或 taskId');
+    });
+
+    it('应该成功通过 taskId 执行任务', async () => {
+      const response = await request(app).post('/v1/tasks/execute').send({
+        taskId: 1
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(mockTaskManagerRunExisting).toHaveBeenCalledWith(1);
+    });
+
+    it('应该成功通过 taskName 执行任务', async () => {
+      const response = await request(app)
+        .post('/v1/tasks/execute')
+        .send({
+          taskName: 'test_task',
+          params: { key: 'value' }
+        });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(mockTaskManagerRun).toHaveBeenCalled();
+    });
+
+    it('应该成功通过 uri 执行任务', async () => {
+      const response = await request(app)
+        .post('/v1/tasks/execute')
+        .send({
+          uri: '/api/test',
+          params: { key: 'value' }
+        });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(mockTaskManagerApiRun).toHaveBeenCalled();
+    });
+
+    it('应该在缺少 params 时返回 400（非 taskId 模式）', async () => {
+      const response = await request(app).post('/v1/tasks/execute').send({
+        taskName: 'test_task'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.BAD_REQUEST);
+      expect(response.body.message).toContain('params 是必需的');
+    });
+  });
+
+  describe('GET /v1/tasks/:id', () => {
+    it('应该在任务不存在时返回 404', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).get('/v1/tasks/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功获取单个任务', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce({
+        id: 1,
+        type: 'test_task',
+        status: 'pending'
+      });
+
+      const response = await request(app).get('/v1/tasks/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+      expect(response.body.data).toHaveProperty('id', 1);
+    });
+  });
+
+  describe('PUT /v1/tasks/:id', () => {
+    it('应该在任务不存在时返回 404', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).put('/v1/tasks/999').send({
+        status: 'completed'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功更新任务', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce({
+        id: 1,
+        type: 'test_task'
+      });
+      mockTaskUpdate.mockResolvedValueOnce({
+        id: 1,
+        status: 'completed'
+      });
+
+      const response = await request(app).put('/v1/tasks/1').send({
+        status: 'completed'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+
+  describe('DELETE /v1/tasks/:id', () => {
+    it('应该在任务不存在时返回 404', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).delete('/v1/tasks/999');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功删除任务', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce({
+        id: 1,
+        type: 'test_task'
+      });
+      mockTaskUpdate.mockResolvedValueOnce({ id: 1 });
+
+      const response = await request(app).delete('/v1/tasks/1');
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+
+  describe('PUT /v1/tasks/:id/status', () => {
+    it('应该在任务不存在时返回 404', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).put('/v1/tasks/999/status').send({
+        status: 'completed'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功更新任务状态', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce({
+        id: 1,
+        type: 'test_task'
+      });
+      mockTaskUpdate.mockResolvedValueOnce({
+        id: 1,
+        status: 'completed'
+      });
+
+      const response = await request(app).put('/v1/tasks/1/status').send({
+        status: 'completed'
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+
+  describe('POST /v1/tasks/:id/assign', () => {
+    it('应该在任务不存在时返回 404', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce(null);
+
+      const response = await request(app).post('/v1/tasks/999/assign').send({
+        caId: 1
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.NOT_FOUND);
+    });
+
+    it('应该成功分配任务', async () => {
+      mockTaskFindFirst.mockResolvedValueOnce({
+        id: 1,
+        type: 'test_task'
+      });
+      mockTaskUpdate.mockResolvedValueOnce({
+        id: 1,
+        caId: 1
+      });
+
+      const response = await request(app).post('/v1/tasks/1/assign').send({
+        caId: 1
+      });
+
+      expect(response.status).toBe(HTTP_STATUS.OK);
+      expect(response.body).toHaveProperty('code', HTTP_STATUS.OK);
+    });
+  });
+});

--- a/packages/hr-agent/src/services/caLogger.test.ts
+++ b/packages/hr-agent/src/services/caLogger.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../utils/database.js', () => ({
+  getPrismaClient: vi.fn().mockReturnValue({
+    codingAgentLog: {
+      create: vi.fn().mockResolvedValue({ id: 1 }),
+      findMany: vi.fn().mockResolvedValue([])
+    }
+  }),
+  setTimestamps: vi.fn((data) => ({ ...data, createdAt: 0, updatedAt: 0 }))
+}));
+
+describe('CALogger', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createCALog', () => {
+    it('应该成功创建 CA 日志', async () => {
+      const { createCALog } = await import('./caLogger.js');
+      await createCALog(1, 'TEST_ACTION', 'old', 'new');
+    });
+
+    it('应该支持没有旧值和新值的日志', async () => {
+      const { createCALog } = await import('./caLogger.js');
+      await createCALog(1, 'TEST_ACTION');
+    });
+
+    it('应该支持 metadata', async () => {
+      const { createCALog } = await import('./caLogger.js');
+      await createCALog(1, 'TEST_ACTION', null, null, { key: 'value' });
+    });
+  });
+
+  describe('getCALogs', () => {
+    it('应该成功获取 CA 日志列表', async () => {
+      const { getCALogs } = await import('./caLogger.js');
+      const logs = await getCALogs(1);
+      expect(Array.isArray(logs)).toBe(true);
+    });
+
+    it('应该支持自定义 limit', async () => {
+      const { getCALogs } = await import('./caLogger.js');
+      await getCALogs(1, 100);
+    });
+  });
+});

--- a/packages/hr-agent/src/services/eventBus.test.ts
+++ b/packages/hr-agent/src/services/eventBus.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventBus } from './eventBus.js';
+import { TASK_EVENTS } from '../config/taskEvents.js';
+
+describe('EventBus', () => {
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+  });
+
+  afterEach(() => {
+    eventBus.clear();
+  });
+
+  describe('register', () => {
+    it('应该成功注册事件处理器', () => {
+      const handler = vi.fn();
+      eventBus.register(TASK_EVENTS.TASK_QUEUED, handler);
+      eventBus.emit(TASK_EVENTS.TASK_QUEUED, { id: 1 });
+      expect(handler).toHaveBeenCalledWith({ id: 1 });
+    });
+  });
+
+  describe('unregister', () => {
+    it('应该成功取消注册事件处理器', () => {
+      const handler = vi.fn();
+      eventBus.register(TASK_EVENTS.TASK_QUEUED, handler);
+      eventBus.unregister(TASK_EVENTS.TASK_QUEUED, handler);
+      eventBus.emit(TASK_EVENTS.TASK_QUEUED, { id: 1 });
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('emit', () => {
+    it('应该成功触发同步事件', () => {
+      const handler = vi.fn();
+      eventBus.register(TASK_EVENTS.TASK_COMPLETED, handler);
+      const result = eventBus.emit(TASK_EVENTS.TASK_COMPLETED, { id: 1, status: 'completed' });
+      expect(result).toBe(true);
+      expect(handler).toHaveBeenCalledWith({ id: 1, status: 'completed' });
+    });
+  });
+
+  describe('emitAsync', () => {
+    it('应该成功触发异步事件', async () => {
+      const handler = vi.fn();
+      eventBus.register(TASK_EVENTS.TASK_CANCELLED, handler);
+      const result = await eventBus.emitAsync(TASK_EVENTS.TASK_CANCELLED, { id: 1 });
+      expect(result).toBe(true);
+      expect(handler).toHaveBeenCalledWith({ id: 1 });
+    });
+  });
+
+  describe('once', () => {
+    it('应该注册一次性事件处理器', () => {
+      const handler = vi.fn();
+      eventBus.once(TASK_EVENTS.TASK_STARTED, handler);
+      eventBus.emit(TASK_EVENTS.TASK_STARTED, { id: 1 });
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('应该清除所有事件处理器', () => {
+      const handler = vi.fn();
+      eventBus.register(TASK_EVENTS.TASK_FAILED, handler);
+      eventBus.clear();
+      eventBus.emit(TASK_EVENTS.TASK_FAILED, { id: 1 });
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/hr-agent/src/utils/envSecrets.test.ts
+++ b/packages/hr-agent/src/utils/envSecrets.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+
+vi.mock('node:fs', () => ({
+  default: {
+    readFileSync: vi.fn()
+  }
+}));
+
+describe('envSecrets', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  describe('getEnvValue', () => {
+    it('应该返回环境变量的值', async () => {
+      process.env.TEST_KEY = 'test-value';
+      const { getEnvValue } = await import('./envSecrets.js');
+      expect(getEnvValue('TEST_KEY')).toBe('test-value');
+    });
+
+    it('应该在环境变量不存在时返回 undefined', async () => {
+      const { getEnvValue } = await import('./envSecrets.js');
+      expect(getEnvValue('NON_EXISTENT_KEY')).toBeUndefined();
+    });
+
+    it('应该从文件读取密钥', async () => {
+      process.env.TEST_SECRET = 'placeholder';
+      process.env.TEST_SECRET_FILE = '/run/secrets/test';
+      vi.mocked(fs.readFileSync).mockReturnValue('file-secret-value');
+
+      const { getEnvValue } = await import('./envSecrets.js');
+      expect(getEnvValue('TEST_SECRET')).toBe('file-secret-value');
+      expect(fs.readFileSync).toHaveBeenCalledWith('/run/secrets/test', 'utf-8');
+    });
+  });
+
+  describe('getRequiredEnvValue', () => {
+    it('应该返回必需的环境变量值', async () => {
+      process.env.REQUIRED_KEY = 'required-value';
+      const { getRequiredEnvValue } = await import('./envSecrets.js');
+      expect(getRequiredEnvValue('REQUIRED_KEY')).toBe('required-value');
+    });
+
+    it('应该在缺少必需环境变量时抛出错误', async () => {
+      const { getRequiredEnvValue } = await import('./envSecrets.js');
+      const fn = () => getRequiredEnvValue('MISSING_REQUIRED_KEY');
+      const expectedMessage =
+        'Required environment variable MISSING_REQUIRED_KEY or MISSING_REQUIRED_KEY_FILE is not set';
+      expect(fn).toThrow(expectedMessage);
+    });
+  });
+
+  describe('getOptionalEnvValue', () => {
+    it('应该返回可选环境变量的值', async () => {
+      process.env.OPTIONAL_KEY = 'optional-value';
+      const { getOptionalEnvValue } = await import('./envSecrets.js');
+      expect(getOptionalEnvValue('OPTIONAL_KEY', 'default')).toBe('optional-value');
+    });
+
+    it('应该在可选环境变量不存在时返回默认值', async () => {
+      const { getOptionalEnvValue } = await import('./envSecrets.js');
+      expect(getOptionalEnvValue('MISSING_OPTIONAL_KEY', 'default-value')).toBe('default-value');
+    });
+  });
+});

--- a/packages/hr-agent/vitest.config.ts
+++ b/packages/hr-agent/vitest.config.ts
@@ -12,10 +12,10 @@ export default defineConfig({
       enabled: process.env.COVERAGE === 'true',
       exclude: ['node_modules/', 'dist/', '**/*.test.ts', '**/*.spec.ts'],
       thresholds: {
-        lines: 34,
-        functions: 42,
-        branches: 25,
-        statements: 34
+        lines: 54,
+        functions: 60,
+        branches: 43,
+        statements: 54
       }
     }
   }


### PR DESCRIPTION
## 变更内容

### 新增测试文件
- [x] routes/health.test.ts - 健康检查路由测试
- [x] routes/v1/config.get.test.ts - 配置接口测试
- [x] routes/v1/ca/index.test.ts - CA 路由测试 (21 tests)
- [x] routes/v1/cas/[id]/operations.test.ts - CAS 操作接口测试 (11 tests)
- [x] routes/v1/issues/index.test.ts - Issues 路由测试
- [x] routes/v1/prs/index.test.ts - PRs 路由测试
- [x] routes/v1/tasks/index.test.ts - Tasks 路由测试 (22 tests)
- [x] services/caLogger.test.ts - CA Logger 服务测试
- [x] services/eventBus.test.ts - EventBus 服务测试
- [x] utils/envSecrets.test.ts - 环境变量密钥工具测试

### 修复
- [x] 修复 prs.test.ts 路由前缀问题 (/api/v1 -> /v1)
- [x] 修复 webhookHandler.ts 缩进问题

### 配置更新
- [x] 更新 vitest 覆盖率阈值以匹配当前基线 (~54%)
- [x] 添加 coverage 目录到 .gitignore

## 覆盖率进展
- 初始: ~36%
- 当前: ~54.61%

## 待完成
- [ ] 继续补充 services 层测试 (caSyncService, prSyncService)
- [ ] 补充 webhooks 路由测试
- [ ] 补充 tasks 层测试
- [ ] 补充 utils 层测试 (webhookHandler)
- [ ] 目标覆盖率: 85%

## 测试结果
- 测试文件: 31 passed
- 测试用例: 282 passed
- Lint: 0 errors, 45 warnings