### PR TITLE
feat(scheduler): 优化 MANAGES_CA 任务的数据库写入和执行间隔

### DIFF
--- a/packages/hr-agent/src/config/taskTags.ts
+++ b/packages/hr-agent/src/config/taskTags.ts
@@ -13,3 +13,5 @@ export type TaskTag = (typeof TASK_TAGS)[keyof typeof TASK_TAGS];
 export const hasTag = (tags: string[], tag: string): boolean => tags.includes(tag);
 
 export const hasRequiresCATag = (tags: string[]): boolean => hasTag(tags, TASK_TAGS.REQUIRES_CA);
+
+export const hasManagesCATag = (tags: string[]): boolean => hasTag(tags, TASK_TAGS.MANAGES_CA);


### PR DESCRIPTION
## 变更内容

### 问题修复
- 修复 container_sync 执行间隔逻辑错误：之前 `lastSyncHadInconsistency = result !== null` 总是为 true，导致间隔一直重置为 10s
- 优化 MANAGES_CA 任务的数据库写入：成功时不写入数据库，只有失败时才记录错误日志

### 实现细节

#### 1. 数据库写入优化
- 为带有 `MANAGES_CA` 标签的任务使用临时负数 taskId
- 成功执行的任务不写入数据库，减少不必要的数据库记录
- 失败的任务会记录错误日志到数据库，包含错误信息和参数

#### 2. 执行间隔修复
- 通过事件监听 `TASK_EVENTS.TASK_COMPLETED` 获取 container_sync 的执行结果
- 根据 `inconsistenciesFound` 和 `errorCount` 判断是否有不一致性
- 只有不一致性时才重置间隔为 10s，否则按 10s, 20s, 30s, 60s, 120s 递增

### 修改文件
- `packages/hr-agent/src/config/taskTags.ts`: 添加 `hasManagesCATag` 辅助函数
- `packages/hr-agent/src/services/taskScheduler.ts`: 
  - 添加临时 taskId 计数器
  - 修改 `addTask` 方法，为 MANAGES_CA 任务跳过数据库写入
  - 修改 `onTaskFailure` 方法，为失败的 MANAGES_CA 任务记录错误日志
  - 修改 `updateTaskStatus` 方法，跳过临时任务的状态更新
- `packages/hr-agent/src/index.ts`:
  - 添加事件监听器获取 container_sync 执行结果
  - 修复 `scheduleContainerSync` 函数的间隔逻辑

### 测试
- [ ] 通过 CI 自动化测试
- [ ] 手动测试 container_sync 执行间隔符合预期
- [ ] 手动测试 MANAGES_CA 任务失败时记录错误日志