### PR TITLE
fix(caProxy): 修复 502 Bad Gateway 错误，增强容器状态检查

### DIFF
--- a/packages/hr-agent/src/middleware/caProxy.test.ts
+++ b/packages/hr-agent/src/middleware/caProxy.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+import caProxyMiddleware from './caProxy.js';
+
+const mockCodingAgentFindFirst = vi.fn();
+const mockGetContainerByName = vi.fn();
+
+vi.mock('../utils/database.js', () => ({
+  getPrismaClient: () => ({
+    codingAgent: {
+      findFirst: mockCodingAgentFindFirst
+    }
+  })
+}));
+
+vi.mock('../utils/docker/getContainer.js', () => ({
+  getContainerByName: () => mockGetContainerByName()
+}));
+
+vi.mock('../config/docker.js', () => ({
+  DOCKER_CONFIG: {
+    PORT: '4096'
+  }
+}));
+
+vi.mock('../utils/envSecrets.js', () => ({
+  getOptionalEnvValue: () => 'http://test.example.com'
+}));
+
+describe('caProxy 中间件测试', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(caProxyMiddleware);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('错误处理', () => {
+    it('当 CA 不在数据库中时，应返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValue(null);
+
+      const response = await request(app).get('/ca/test-ca/');
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({
+        code: 404,
+        message: 'CA "test-ca" not found in database'
+      });
+    });
+
+    it('当 Docker 容器不存在时，应返回 404', async () => {
+      mockCodingAgentFindFirst.mockResolvedValue({ caName: 'test-ca' });
+      mockGetContainerByName.mockResolvedValue(null);
+
+      const response = await request(app).get('/ca/test-ca/');
+
+      expect(response.status).toBe(404);
+      expect(response.body.code).toBe(404);
+      expect(response.body.message).toContain('Docker container "test-ca" not found');
+    });
+
+    it('当容器未运行时，应返回 503', async () => {
+      mockCodingAgentFindFirst.mockResolvedValue({ caName: 'test-ca' });
+      mockGetContainerByName.mockResolvedValue({
+        id: 'container-id',
+        name: 'test-ca',
+        status: 'exited',
+        state: false,
+        created: '2024-01-01T00:00:00Z'
+      });
+
+      const response = await request(app).get('/ca/test-ca/');
+
+      expect(response.status).toBe(503);
+      expect(response.body.code).toBe(503);
+      expect(response.body.message).toContain('CA container "test-ca" is not running');
+    });
+  });
+
+  describe('代理功能', () => {
+    it('应正确处理非 /ca 路径的请求', async () => {
+      const response = await request(app).get('/other-path');
+
+      expect(response.status).toBe(404);
+    });
+  });
+});

--- a/packages/hr-agent/src/middleware/caProxy.ts
+++ b/packages/hr-agent/src/middleware/caProxy.ts
@@ -4,10 +4,14 @@ import { Buffer } from 'node:buffer';
 import { DOCKER_CONFIG } from '../config/docker.js';
 import { getOptionalEnvValue } from '../utils/envSecrets.js';
 import { getPrismaClient } from '../utils/database.js';
+import { getContainerByName } from '../utils/docker/getContainer.js';
 
 const CA_PROXY_PATH = '/ca';
 const HTTP_OK = 200;
 const HTTP_BAD_GATEWAY = 502;
+const HTTP_NOT_FOUND = 404;
+const HTTP_SERVICE_UNAVAILABLE = 503;
+const PROXY_TIMEOUT_MS = 30000;
 
 const CSP_DOMAIN = getOptionalEnvValue('CSP_DOMAIN', 'http://rha.onemue.cn');
 
@@ -57,6 +61,52 @@ async function getContainerNameByCAName(caName: string): Promise<string | null> 
   }
 }
 
+function handleProxyResponse(
+  proxyRes: http.IncomingMessage,
+  res: Response,
+  caName: string
+): void {
+  const chunks: Buffer[] = [];
+
+  proxyRes.on('data', (chunk) => {
+    chunks.push(chunk);
+  });
+
+  proxyRes.on('end', () => {
+    const buffer = Buffer.concat(chunks);
+    const contentType = proxyRes.headers['content-type'];
+
+    res.status(proxyRes.statusCode ?? HTTP_OK);
+
+    Object.entries(proxyRes.headers).forEach(([key, value]) => {
+      if (!value) {
+        return;
+      }
+
+      if (key.toLowerCase() === 'set-cookie') {
+        res.setHeader(key, modifySetCookie(value, caName));
+      } else if (key.toLowerCase() === 'content-security-policy') {
+        const csp = String(value).replace(
+          /default-src [^;]+/gi,
+          `default-src 'self' ${CSP_DOMAIN}`
+        );
+        res.setHeader(key, csp);
+      } else {
+        res.setHeader(key, value);
+      }
+    });
+
+    if (contentType?.includes('text/html')) {
+      const html = buffer.toString('utf8');
+      const basePath = `${CA_PROXY_PATH}/${caName}/`;
+      const modifiedHtml = injectBaseTag(html, basePath);
+      res.send(modifiedHtml);
+    } else {
+      res.send(buffer);
+    }
+  });
+}
+
 async function caProxyMiddleware(req: Request, res: Response, next: NextFunction): Promise<void> {
   const originalUrl = req.originalUrl ?? req.url;
   const match = originalUrl.match(new RegExp(`^${CA_PROXY_PATH}/([^/]+)(.*)$`));
@@ -71,9 +121,27 @@ async function caProxyMiddleware(req: Request, res: Response, next: NextFunction
   const containerName = await getContainerNameByCAName(caName);
 
   if (!containerName) {
-    res.status(HTTP_BAD_GATEWAY).json({
-      code: HTTP_BAD_GATEWAY,
-      message: `CA container for "${caName}" not found`
+    res.status(HTTP_NOT_FOUND).json({
+      code: HTTP_NOT_FOUND,
+      message: `CA "${caName}" not found in database`
+    });
+    return;
+  }
+
+  const dockerContainer = await getContainerByName(containerName);
+
+  if (!dockerContainer) {
+    res.status(HTTP_NOT_FOUND).json({
+      code: HTTP_NOT_FOUND,
+      message: `Docker container "${containerName}" not found. Please ensure the CA container is created.`
+    });
+    return;
+  }
+
+  if (!dockerContainer.state) {
+    res.status(HTTP_SERVICE_UNAVAILABLE).json({
+      code: HTTP_SERVICE_UNAVAILABLE,
+      message: `CA container "${containerName}" is not running (status: ${dockerContainer.status}). Please start the container.`
     });
     return;
   }
@@ -84,6 +152,7 @@ async function caProxyMiddleware(req: Request, res: Response, next: NextFunction
     targetUrl + subPath,
     {
       method: req.method,
+      timeout: PROXY_TIMEOUT_MS,
       headers: {
         ...req.headers,
         host: `${containerName}:${DOCKER_CONFIG.PORT}`,
@@ -91,54 +160,23 @@ async function caProxyMiddleware(req: Request, res: Response, next: NextFunction
         'x-forwarded-proto': req.protocol
       }
     },
-    (proxyRes) => {
-      const chunks: Buffer[] = [];
-
-      proxyRes.on('data', (chunk) => {
-        chunks.push(chunk);
-      });
-
-      proxyRes.on('end', () => {
-        const buffer = Buffer.concat(chunks);
-        const contentType = proxyRes.headers['content-type'];
-
-        res.status(proxyRes.statusCode ?? HTTP_OK);
-
-        Object.entries(proxyRes.headers).forEach(([key, value]) => {
-          if (!value) {
-            return;
-          }
-
-          if (key.toLowerCase() === 'set-cookie') {
-            res.setHeader(key, modifySetCookie(value, caName));
-          } else if (key.toLowerCase() === 'content-security-policy') {
-            const csp = String(value).replace(
-              /default-src [^;]+/gi,
-              `default-src 'self' ${CSP_DOMAIN}`
-            );
-            res.setHeader(key, csp);
-          } else {
-            res.setHeader(key, value);
-          }
-        });
-
-        if (contentType?.includes('text/html')) {
-          const html = buffer.toString('utf8');
-          const basePath = `${CA_PROXY_PATH}/${caName}/`;
-          const modifiedHtml = injectBaseTag(html, basePath);
-          res.send(modifiedHtml);
-        } else {
-          res.send(buffer);
-        }
-      });
-    }
+    (proxyRes) => handleProxyResponse(proxyRes, res, caName)
   );
 
   proxyReq.on('error', (err) => {
     console.error(`Proxy error for ${originalUrl}:`, err.message);
     res.status(HTTP_BAD_GATEWAY).json({
       code: HTTP_BAD_GATEWAY,
-      message: `Failed to proxy to CA container: ${err.message}`
+      message: `Failed to proxy to CA container "${containerName}": ${err.message}`
+    });
+  });
+
+  proxyReq.on('timeout', () => {
+    console.error(`Proxy timeout for ${originalUrl}`);
+    proxyReq.destroy();
+    res.status(HTTP_BAD_GATEWAY).json({
+      code: HTTP_BAD_GATEWAY,
+      message: `Proxy request to CA container "${containerName}" timed out after ${PROXY_TIMEOUT_MS}ms`
     });
   });
 


### PR DESCRIPTION
## 变更内容

### 问题分析
访问 https://hra.onemue.cn/ca/hra_test/ 时出现 502 Bad Gateway 错误。

**根本原因**：
1. caProxy 中间件在代理请求时，没有检查 Docker 容器是否实际存在和运行
2. 缺少请求超时设置，可能导致长时间挂起
3. 错误信息不够明确，难以排查问题

### 解决方案

#### 1. 增强容器状态检查
- 在代理请求前，先检查 Docker 容器是否存在
- 验证容器是否处于运行状态
- 区分不同错误类型：
  - 404: CA 不在数据库中
  - 404: Docker 容器不存在
  - 503: 容器存在但未运行
  - 502: 代理请求失败

#### 2. 添加超时处理
- 设置 30 秒代理请求超时
- 防止长时间挂起等待
- 提供明确的超时错误信息

#### 3. 改进错误信息
- 提供详细的错误描述
- 包含容器名称和状态信息
- 便于快速定位问题

#### 4. 代码重构
- 提取 handleProxyResponse 函数，降低函数复杂度
- 改善代码可读性和可维护性

### 测试覆盖

添加了完整的单元测试，覆盖以下场景：
- ✅ CA 不在数据库中时返回 404
- ✅ Docker 容器不存在时返回 404
- ✅ 容器未运行时返回 503
- ✅ 非 /ca 路径请求正确处理

### 检查清单
- [x] 功能实现
- [x] 单元测试
- [x] 类型检查通过
- [x] Lint 检查通过（仅有警告，无错误）
- [x] 所有测试通过
- [ ] CI 通过（待确认）

### 相关文件
- `packages/hr-agent/src/middleware/caProxy.ts` - 修复的主要文件
- `packages/hr-agent/src/middleware/caProxy.test.ts` - 新增测试文件