### PR TITLE
fix(caProxy): 修复 CA 容器 CSP 内联脚本问题

### DIFF
--- a/packages/hr-agent/src/middleware/caProxy.ts
+++ b/packages/hr-agent/src/middleware/caProxy.ts
@@ -87,10 +87,9 @@ function handleProxyResponse(proxyRes: http.IncomingMessage, res: Response, caNa
       if (key.toLowerCase() === 'set-cookie') {
         res.setHeader(key, modifySetCookie(value, caName));
       } else if (key.toLowerCase() === 'content-security-policy') {
-        const csp = String(value).replace(
-          /default-src [^;]+/gi,
-          `default-src 'self' ${CSP_DOMAIN}`
-        );
+        let csp = String(value);
+        csp = csp.replace(/default-src [^;]+/gi, `default-src 'self' ${CSP_DOMAIN}`);
+        csp = csp.replace(/script-src [^;]+/gi, `script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' ${CSP_DOMAIN}`);
         res.setHeader(key, csp);
       } else {
         res.setHeader(key, value);


### PR DESCRIPTION
## Summary
- 修复 CA 代理的 CSP (Content Security Policy) 问题
- 在 `script-src` 指令中添加 `'wasm-unsafe-eval'` 和 `'unsafe-inline'`
- 允许 CA 容器(opencode-ai)的内联脚本正常执行

## Changes
- `packages/hr-agent/src/middleware/caProxy.ts`: 修改 CSP 头处理逻辑

## Test
- [x] 本地测试通过 (364 tests passed)
- [x] TypeCheck 通过
- [x] Lint 通过