### PR TITLE
refactor(overview): update Issue and PR stats display format

### DIFF
--- a/packages/hr-agent-web/src/components/DashboardOverview/IssueOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/IssueOverview.tsx
@@ -1,21 +1,57 @@
 import { AlertOutlined } from '@ant-design/icons';
-import { Tag } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { useIssues } from '../../hooks/useIssues';
 import { OverviewCard } from './OverviewCard';
 
-export function IssueOverview() {
-  const navigate = useNavigate();
+interface IssueStats {
+  total: number;
+  inProgress: number;
+  completed: number;
+  deleted: number;
+}
+
+function useIssueStats(): { stats: IssueStats; isLoading: boolean } {
   const { data, isLoading } = useIssues({ page: 1, pageSize: 100 });
 
   const issues = data?.issues || [];
   const pagination = data?.pagination;
 
-  const total = pagination?.total || issues.length;
+  const stats: IssueStats = {
+    total: pagination?.total || issues.length,
+    inProgress: issues.filter((i) => i.completedAt < 0 && i.deletedAt < 0).length,
+    completed: issues.filter((i) => i.completedAt >= 0).length,
+    deleted: issues.filter((i) => i.deletedAt >= 0).length
+  };
 
-  const inProgressCount = issues.filter((i) => i.completedAt < 0 && i.deletedAt < 0).length;
-  const completedCount = issues.filter((i) => i.completedAt >= 0).length;
-  const deletedCount = issues.filter((i) => i.deletedAt >= 0).length;
+  return { stats, isLoading };
+}
+
+function IssueStatsContent({ stats }: { stats: IssueStats }) {
+  return (
+    <>
+      <div className="overview-stat">
+        <span className="overview-stat-label">总 Issue 数</span>
+        <span className="overview-stat-value">{stats.total}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">进行中</span>
+        <span className="overview-stat-value running">{stats.inProgress}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">已完成</span>
+        <span className="overview-stat-value success">{stats.completed}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">已删除</span>
+        <span className="overview-stat-value error">{stats.deleted}</span>
+      </div>
+    </>
+  );
+}
+
+export function IssueOverview() {
+  const navigate = useNavigate();
+  const { stats, isLoading } = useIssueStats();
 
   return (
     <OverviewCard
@@ -24,24 +60,7 @@ export function IssueOverview() {
       loading={isLoading}
       onClick={() => navigate('/issues')}
     >
-      <div className="overview-stat">
-        <span className="overview-stat-label">总 Issue 数</span>
-        <span className="overview-stat-value">{total}</span>
-      </div>
-      <div className="overview-stat-group">
-        <div className="overview-stat-item">
-          <Tag color="processing">进行中</Tag>
-          <span className="overview-stat-count">{inProgressCount}</span>
-        </div>
-        <div className="overview-stat-item">
-          <Tag color="success">已完成</Tag>
-          <span className="overview-stat-count">{completedCount}</span>
-        </div>
-        <div className="overview-stat-item">
-          <Tag color="default">已删除</Tag>
-          <span className="overview-stat-count">{deletedCount}</span>
-        </div>
-      </div>
+      <IssueStatsContent stats={stats} />
     </OverviewCard>
   );
 }

--- a/packages/hr-agent-web/src/components/DashboardOverview/PrOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/PrOverview.tsx
@@ -1,21 +1,57 @@
 import { PullRequestOutlined } from '@ant-design/icons';
-import { Tag } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { usePRs } from '../../hooks/usePrs';
 import { OverviewCard } from './OverviewCard';
 
-export function PrOverview() {
-  const navigate = useNavigate();
+interface PRStats {
+  total: number;
+  inProgress: number;
+  merged: number;
+  deleted: number;
+}
+
+function usePRStats(): { stats: PRStats; isLoading: boolean } {
   const { data, isLoading } = usePRs({ page: 1, pageSize: 100 });
 
   const prs = data?.prs || [];
   const pagination = data?.pagination;
 
-  const total = pagination?.total || prs.length;
+  const stats: PRStats = {
+    total: pagination?.total || prs.length,
+    inProgress: prs.filter((p) => p.completedAt < 0 && p.deletedAt < 0).length,
+    merged: prs.filter((p) => p.completedAt >= 0).length,
+    deleted: prs.filter((p) => p.deletedAt >= 0).length
+  };
 
-  const inProgressCount = prs.filter((p) => p.completedAt < 0 && p.deletedAt < 0).length;
-  const mergedCount = prs.filter((p) => p.completedAt >= 0).length;
-  const deletedCount = prs.filter((p) => p.deletedAt >= 0).length;
+  return { stats, isLoading };
+}
+
+function PRStatsContent({ stats }: { stats: PRStats }) {
+  return (
+    <>
+      <div className="overview-stat">
+        <span className="overview-stat-label">总 PR 数</span>
+        <span className="overview-stat-value">{stats.total}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">进行中</span>
+        <span className="overview-stat-value running">{stats.inProgress}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">已合并</span>
+        <span className="overview-stat-value success">{stats.merged}</span>
+      </div>
+      <div className="overview-stat">
+        <span className="overview-stat-label">已删除</span>
+        <span className="overview-stat-value error">{stats.deleted}</span>
+      </div>
+    </>
+  );
+}
+
+export function PrOverview() {
+  const navigate = useNavigate();
+  const { stats, isLoading } = usePRStats();
 
   return (
     <OverviewCard
@@ -24,24 +60,7 @@ export function PrOverview() {
       loading={isLoading}
       onClick={() => navigate('/prs')}
     >
-      <div className="overview-stat">
-        <span className="overview-stat-label">总 PR 数</span>
-        <span className="overview-stat-value">{total}</span>
-      </div>
-      <div className="overview-stat-group">
-        <div className="overview-stat-item">
-          <Tag color="processing">进行中</Tag>
-          <span className="overview-stat-count">{inProgressCount}</span>
-        </div>
-        <div className="overview-stat-item">
-          <Tag color="success">已合并</Tag>
-          <span className="overview-stat-count">{mergedCount}</span>
-        </div>
-        <div className="overview-stat-item">
-          <Tag color="default">已删除</Tag>
-          <span className="overview-stat-count">{deletedCount}</span>
-        </div>
-      </div>
+      <PRStatsContent stats={stats} />
     </OverviewCard>
   );
 }


### PR DESCRIPTION
## 变更内容
- [x] 修改 IssueOverview.tsx 统计展示格式
- [x] 修改 PrOverview.tsx 统计展示格式
- [x] 测试用例全部通过

## 变更详情
将 Issue 和 PR 的统计展示从 Tag + stat-group 格式改为与 CA Overview 一致的扁平化格式:
- 移除 Tag 组件依赖
- 使用 `overview-stat` + 颜色类名 (running/success/error)
- 提取 useIssueStats 和 usePRStats hooks
- 提取 IssueStatsContent 和 PRStatsContent 组件