### PR TITLE
fix(ui): replace transparent background with solid color for table cells

### DIFF
--- a/packages/hr-agent-web/src/pages/Cas/index.css
+++ b/packages/hr-agent-web/src/pages/Cas/index.css
@@ -95,7 +95,7 @@
 }
 
 .cas-card .ant-table-tbody > tr > td {
-  background: transparent !important;
+  background: var(--bg-glass) !important;
   color: var(--text-primary) !important;
   border-bottom: 1px solid var(--border-glass) !important;
   transition: all 0.3s ease;

--- a/packages/hr-agent-web/src/pages/Issues/index.css
+++ b/packages/hr-agent-web/src/pages/Issues/index.css
@@ -54,7 +54,7 @@
 }
 
 .issues-card .ant-table-tbody > tr > td {
-  background: transparent !important;
+  background: var(--bg-glass) !important;
   color: var(--text-primary) !important;
   border-bottom: 1px solid var(--border-glass) !important;
   transition: all 0.3s ease;

--- a/packages/hr-agent-web/src/pages/Prs/index.css
+++ b/packages/hr-agent-web/src/pages/Prs/index.css
@@ -54,7 +54,7 @@
 }
 
 .prs-card .ant-table-tbody > tr > td {
-  background: transparent !important;
+  background: var(--bg-glass) !important;
   color: var(--text-primary) !important;
   border-bottom: 1px solid var(--border-glass) !important;
   transition: all 0.3s ease;

--- a/packages/hr-agent-web/src/pages/TaskList/index.css
+++ b/packages/hr-agent-web/src/pages/TaskList/index.css
@@ -132,7 +132,7 @@
 
 .task-list-card .ant-table-tbody > tr > td {
   border-bottom: 1px solid var(--border-glass) !important;
-  background: transparent !important;
+  background: var(--bg-glass) !important;
   color: var(--text-primary);
   transition: all 0.3s ease;
 }


### PR DESCRIPTION
## 变更内容
- [x] 修改 `.ant-table-tbody > tr > td` 的背景色从 `transparent` 改为 `var(--bg-glass)`
- [x] 影响页面: TaskList, Issues, Prs, Cas

## 技术说明
将表格单元格的透明背景替换为使用 CSS 变量定义的玻璃效果背景色，解决表格背景透明问题。