### PR TITLE
feat(ca): 支持 git 仓库地址配置

### DIFF
--- a/packages/hr-agent/src/routes/v1/ca/add.post.ts
+++ b/packages/hr-agent/src/routes/v1/ca/add.post.ts
@@ -93,9 +93,9 @@ export default async function newCARoute(req: Request, res: Response): Promise<v
       status: 'pending_create',
       dockerConfig: {
         image: DOCKER_CONFIG.IMAGE,
-        network: DOCKER_CONFIG.NETWORK
+        network: DOCKER_CONFIG.NETWORK,
+        repoUrl
       },
-      metadata: repoUrl ? { repoUrl } : undefined,
       createdAt: 0,
       updatedAt: 0,
       completedAt: INACTIVE_TIMESTAMP,

--- a/packages/hr-agent/src/tasks/containerCreateTask.test.ts
+++ b/packages/hr-agent/src/tasks/containerCreateTask.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ContainerCreateTask } from './containerCreateTask.js';
+import { EventBus } from '../services/eventBus.js';
+import { TaskLogger } from '../utils/taskLogger.js';
+import { TASK_TAGS } from '../config/taskTags.js';
+
+vi.mock('../utils/docker/createContainer.js', () => ({
+  createContainer: vi.fn()
+}));
+
+vi.mock('../utils/database.js', () => ({
+  getPrismaClient: vi.fn(() => ({
+    codingAgent: {
+      findUnique: vi.fn(),
+      update: vi.fn()
+    }
+  })),
+  getCurrentTimestamp: vi.fn(() => Date.now())
+}));
+
+type MockPrismaClient = {
+  codingAgent: {
+    findUnique: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe('ContainerCreateTask', () => {
+  let task: ContainerCreateTask;
+  let eventBus: EventBus;
+  let logger: TaskLogger;
+  let mockCreateContainer: ReturnType<typeof vi.fn>;
+  let mockPrisma: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    eventBus = new EventBus();
+    logger = new TaskLogger();
+    vi.spyOn(logger, 'info').mockResolvedValue(undefined);
+    vi.spyOn(logger, 'warn').mockResolvedValue(undefined);
+    vi.spyOn(logger, 'error').mockResolvedValue(undefined);
+
+    task = new ContainerCreateTask(eventBus, logger);
+
+    const { createContainer } = await import('../utils/docker/createContainer.js');
+    mockCreateContainer = vi.mocked(createContainer);
+    mockCreateContainer.mockClear();
+
+    const { getPrismaClient } = await import('../utils/database.js');
+    mockPrisma = vi.mocked(getPrismaClient);
+    mockPrisma.mockClear();
+  });
+
+  describe('execute', () => {
+    it('应该从 dockerConfig 中读取 repoUrl 并传递给 createContainer', async () => {
+      const repoUrl = 'git@github.com:owner/repo.git';
+      const mockCARecord = {
+        id: 1,
+        caName: 'test-ca',
+        status: 'pending_create',
+        dockerConfig: {
+          image: 'test-image',
+          network: 'test-network',
+          repoUrl
+        }
+      };
+
+      mockPrisma.mockReturnValue({
+        codingAgent: {
+          findUnique: vi.fn().mockResolvedValue(mockCARecord),
+          update: vi.fn().mockResolvedValue({})
+        }
+      } as unknown as MockPrismaClient);
+
+      mockCreateContainer.mockResolvedValue('container-id-123');
+
+      const result = await task.execute(
+        { caId: 1, caName: 'test-ca' },
+        { taskId: 1, taskName: 'container_create', retryCount: 0 }
+      );
+
+      expect(mockCreateContainer).toHaveBeenCalledWith('test-ca', repoUrl);
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        caId: 1,
+        caName: 'test-ca',
+        containerId: 'container-id-123'
+      });
+    });
+
+    it('当没有 repoUrl 时应该传递 undefined 给 createContainer', async () => {
+      const mockCARecord = {
+        id: 1,
+        caName: 'test-ca',
+        status: 'pending_create',
+        dockerConfig: {
+          image: 'test-image',
+          network: 'test-network'
+        }
+      };
+
+      mockPrisma.mockReturnValue({
+        codingAgent: {
+          findUnique: vi.fn().mockResolvedValue(mockCARecord),
+          update: vi.fn().mockResolvedValue({})
+        }
+      } as unknown as MockPrismaClient);
+
+      mockCreateContainer.mockResolvedValue('container-id-123');
+
+      const result = await task.execute(
+        { caId: 1, caName: 'test-ca' },
+        { taskId: 1, taskName: 'container_create', retryCount: 0 }
+      );
+
+      expect(mockCreateContainer).toHaveBeenCalledWith('test-ca', undefined);
+      expect(result.success).toBe(true);
+    });
+
+    it('当 dockerConfig 为 null 时应该传递 undefined 给 createContainer', async () => {
+      const mockCARecord = {
+        id: 1,
+        caName: 'test-ca',
+        status: 'pending_create',
+        dockerConfig: null
+      };
+
+      mockPrisma.mockReturnValue({
+        codingAgent: {
+          findUnique: vi.fn().mockResolvedValue(mockCARecord),
+          update: vi.fn().mockResolvedValue({})
+        }
+      } as unknown as MockPrismaClient);
+
+      mockCreateContainer.mockResolvedValue('container-id-123');
+
+      const result = await task.execute(
+        { caId: 1, caName: 'test-ca' },
+        { taskId: 1, taskName: 'container_create', retryCount: 0 }
+      );
+
+      expect(mockCreateContainer).toHaveBeenCalledWith('test-ca', undefined);
+      expect(result.success).toBe(true);
+    });
+
+    it('当 CA 状态不是 pending_create 时应该跳过创建', async () => {
+      const mockCARecord = {
+        id: 1,
+        caName: 'test-ca',
+        status: 'idle',
+        dockerConfig: {}
+      };
+
+      mockPrisma.mockReturnValue({
+        codingAgent: {
+          findUnique: vi.fn().mockResolvedValue(mockCARecord),
+          update: vi.fn().mockResolvedValue({})
+        }
+      } as unknown as MockPrismaClient);
+
+      const result = await task.execute(
+        { caId: 1, caName: 'test-ca' },
+        { taskId: 1, taskName: 'container_create', retryCount: 0 }
+      );
+
+      expect(mockCreateContainer).not.toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        caId: 1,
+        caName: 'test-ca',
+        skipped: true,
+        reason: 'status_not_pending_create'
+      });
+    });
+
+    it('当 CA 记录不存在时应该返回错误', async () => {
+      mockPrisma.mockReturnValue({
+        codingAgent: {
+          findUnique: vi.fn().mockResolvedValue(null),
+          update: vi.fn().mockResolvedValue({})
+        }
+      } as unknown as MockPrismaClient);
+
+      const result = await task.execute(
+        { caId: 999, caName: 'non-existent-ca' },
+        { taskId: 1, taskName: 'container_create', retryCount: 0 }
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('CA 记录不存在');
+    });
+  });
+
+  describe('任务属性', () => {
+    it('应该有正确的 name 属性', () => {
+      expect(task.name).toBe('container_create');
+    });
+
+    it('应该有空的 dependencies', () => {
+      expect(task.dependencies).toEqual([]);
+    });
+
+    it('应该有 MANAGES_CA tag', () => {
+      expect(task.tags).toContain(TASK_TAGS.MANAGES_CA);
+    });
+  });
+});

--- a/packages/hr-agent/src/tasks/containerCreateTask.ts
+++ b/packages/hr-agent/src/tasks/containerCreateTask.ts
@@ -45,7 +45,10 @@ export class ContainerCreateTask extends BaseTask {
         data: { status: 'creating', updatedAt: now }
       });
 
-      const containerId = await createContainer(caName);
+      const dockerConfig = caRecord.dockerConfig as { repoUrl?: string } | null;
+      const repoUrl = dockerConfig?.repoUrl;
+
+      const containerId = await createContainer(caName, repoUrl);
 
       await prisma.codingAgent.update({
         where: { id: caId },

--- a/packages/hr-agent/src/utils/docker/createContainer.ts
+++ b/packages/hr-agent/src/utils/docker/createContainer.ts
@@ -36,7 +36,7 @@ export async function createContainer(name: string, repoUrl?: string): Promise<s
       `OPENCODE_SERVER_PASSWORD=${DOCKER_CONFIG.SECRET}`
     ];
     if (repoUrl) {
-      envVars.push(`REPO_URL=${repoUrl}`);
+      envVars.push(`GITHUB_REPO_URL=${repoUrl}`);
     }
 
     const container = await docker.createContainer({


### PR DESCRIPTION
## 变更内容

- [x] 修复环境变量名不一致：createContainer.ts 使用 GITHUB_REPO_URL（与 Dockerfile 保持一致）
- [x] 修改 add.post.ts 将 repoUrl 存储到 dockerConfig 字段（而不是不存在的 metadata 字段）
- [x] 修改 ContainerCreateTask 从 CA 记录的 dockerConfig 中读取 repoUrl 并传递给 createContainer
- [x] 添加 ContainerCreateTask 测试用例验证 repoUrl 传递逻辑

## 功能说明

支持在创建 CA（Coding Agent）时配置 git 仓库地址。CA 容器在初始化时会自动拉取配置的仓库，后续任务执行都在该仓库基础上进行。

### 使用方式

通过 API 创建 CA 时传递 repoUrl 参数：

```json
POST /v1/ca/add
{
  "name": "my-ca",
  "repoUrl": "git@github.com:owner/repo.git"
}
```

CA 容器启动时会自动克隆该仓库到 `/home/workspace/repo` 目录。

## 测试覆盖

- ✅ repoUrl 正常传递场景
- ✅ repoUrl 为空的场景
- ✅ dockerConfig 为 null 的场景
- ✅ CA 状态检查场景
- ✅ CA 记录不存在场景

## 检查结果

- ✅ TypeScript 类型检查通过
- ✅ ESLint 检查通过（无新增错误）
- ✅ 所有测试用例通过