### PR TITLE
refactor(web): use Ant Design CSS variables instead of hardcoded colors

### DIFF
--- a/packages/hr-agent-web/src/components/DashboardOverview/CaOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/CaOverview.tsx
@@ -1,6 +1,7 @@
 import { RobotOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import type { CSSProperties } from 'react';
+import { theme } from 'antd';
 import { useCodingAgents, useCAStatus } from '../../hooks/useCas';
 import { OverviewCard } from './OverviewCard';
 
@@ -17,10 +18,6 @@ const statStyle: CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '8px 0'
-};
-
-const labelStyle: CSSProperties = {
-  color: '#8c8c8c'
 };
 
 const valueStyle: CSSProperties = {
@@ -56,6 +53,12 @@ function useCAStats(): { stats: CAStats; isLoading: boolean } {
 }
 
 function CAStatsContent({ stats }: { stats: CAStats }) {
+  const { token } = theme.useToken();
+
+  const labelStyle: CSSProperties = {
+    color: token.colorTextSecondary
+  };
+
   return (
     <>
       <div style={statStyle}>
@@ -64,20 +67,20 @@ function CAStatsContent({ stats }: { stats: CAStats }) {
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>运行中</span>
-        <span style={{ ...valueStyle, color: '#1890ff' }}>{stats.running}</span>
+        <span style={{ ...valueStyle, color: token.colorPrimary }}>{stats.running}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>空闲</span>
-        <span style={{ ...valueStyle, color: '#52c41a' }}>{stats.idle}</span>
+        <span style={{ ...valueStyle, color: token.colorSuccess }}>{stats.idle}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>错误</span>
-        <span style={{ ...valueStyle, color: '#ff4d4f' }}>{stats.error}</span>
+        <span style={{ ...valueStyle, color: token.colorError }}>{stats.error}</span>
       </div>
       {stats.creating > 0 && (
         <div style={statStyle}>
           <span style={labelStyle}>创建中</span>
-          <span style={{ ...valueStyle, color: '#faad14' }}>{stats.creating}</span>
+          <span style={{ ...valueStyle, color: token.colorWarning }}>{stats.creating}</span>
         </div>
       )}
     </>

--- a/packages/hr-agent-web/src/components/DashboardOverview/IssueOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/IssueOverview.tsx
@@ -1,6 +1,7 @@
 import { AlertOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import type { CSSProperties } from 'react';
+import { theme } from 'antd';
 import { useIssues } from '../../hooks/useIssues';
 import { OverviewCard } from './OverviewCard';
 
@@ -16,10 +17,6 @@ const statStyle: CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '8px 0'
-};
-
-const labelStyle: CSSProperties = {
-  color: '#8c8c8c'
 };
 
 const valueStyle: CSSProperties = {
@@ -44,6 +41,12 @@ function useIssueStats(): { stats: IssueStats; isLoading: boolean } {
 }
 
 function IssueStatsContent({ stats }: { stats: IssueStats }) {
+  const { token } = theme.useToken();
+
+  const labelStyle: CSSProperties = {
+    color: token.colorTextSecondary
+  };
+
   return (
     <>
       <div style={statStyle}>
@@ -52,15 +55,15 @@ function IssueStatsContent({ stats }: { stats: IssueStats }) {
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>进行中</span>
-        <span style={{ ...valueStyle, color: '#1890ff' }}>{stats.inProgress}</span>
+        <span style={{ ...valueStyle, color: token.colorPrimary }}>{stats.inProgress}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>已完成</span>
-        <span style={{ ...valueStyle, color: '#52c41a' }}>{stats.completed}</span>
+        <span style={{ ...valueStyle, color: token.colorSuccess }}>{stats.completed}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>已删除</span>
-        <span style={{ ...valueStyle, color: '#ff4d4f' }}>{stats.deleted}</span>
+        <span style={{ ...valueStyle, color: token.colorError }}>{stats.deleted}</span>
       </div>
     </>
   );

--- a/packages/hr-agent-web/src/components/DashboardOverview/OverviewCard.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/OverviewCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Skeleton, Typography } from 'antd';
+import { Card, Skeleton, Typography, theme } from 'antd';
 import type { ReactNode } from 'react';
 
 const { Title } = Typography;
@@ -12,10 +12,12 @@ interface OverviewCardProps {
 }
 
 export function OverviewCard({ title, icon, loading, children, onClick }: OverviewCardProps) {
+  const { token } = theme.useToken();
+
   return (
     <Card hoverable={!!onClick} onClick={onClick}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-        <div style={{ fontSize: 20, color: '#9333EA' }}>{icon}</div>
+        <div style={{ fontSize: 20, color: token.colorPrimary }}>{icon}</div>
         <Title level={4} style={{ margin: 0 }}>
           {title}
         </Title>

--- a/packages/hr-agent-web/src/components/DashboardOverview/PrOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/PrOverview.tsx
@@ -1,6 +1,7 @@
 import { PullRequestOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import type { CSSProperties } from 'react';
+import { theme } from 'antd';
 import { usePRs } from '../../hooks/usePrs';
 import { OverviewCard } from './OverviewCard';
 
@@ -16,10 +17,6 @@ const statStyle: CSSProperties = {
   justifyContent: 'space-between',
   alignItems: 'center',
   padding: '8px 0'
-};
-
-const labelStyle: CSSProperties = {
-  color: '#8c8c8c'
 };
 
 const valueStyle: CSSProperties = {
@@ -44,6 +41,12 @@ function usePRStats(): { stats: PRStats; isLoading: boolean } {
 }
 
 function PRStatsContent({ stats }: { stats: PRStats }) {
+  const { token } = theme.useToken();
+
+  const labelStyle: CSSProperties = {
+    color: token.colorTextSecondary
+  };
+
   return (
     <>
       <div style={statStyle}>
@@ -52,15 +55,15 @@ function PRStatsContent({ stats }: { stats: PRStats }) {
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>进行中</span>
-        <span style={{ ...valueStyle, color: '#1890ff' }}>{stats.inProgress}</span>
+        <span style={{ ...valueStyle, color: token.colorPrimary }}>{stats.inProgress}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>已合并</span>
-        <span style={{ ...valueStyle, color: '#52c41a' }}>{stats.merged}</span>
+        <span style={{ ...valueStyle, color: token.colorSuccess }}>{stats.merged}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>已删除</span>
-        <span style={{ ...valueStyle, color: '#ff4d4f' }}>{stats.deleted}</span>
+        <span style={{ ...valueStyle, color: token.colorError }}>{stats.deleted}</span>
       </div>
     </>
   );

--- a/packages/hr-agent-web/src/components/DashboardOverview/TaskOverview.tsx
+++ b/packages/hr-agent-web/src/components/DashboardOverview/TaskOverview.tsx
@@ -1,6 +1,7 @@
 import { FileTextOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import type { CSSProperties } from 'react';
+import { theme } from 'antd';
 import { useTasks } from '../../hooks/useTasks';
 import { OverviewCard } from './OverviewCard';
 
@@ -11,10 +12,6 @@ const statStyle: CSSProperties = {
   padding: '8px 0'
 };
 
-const labelStyle: CSSProperties = {
-  color: '#8c8c8c'
-};
-
 const valueStyle: CSSProperties = {
   fontSize: 16,
   fontWeight: 600
@@ -23,6 +20,7 @@ const valueStyle: CSSProperties = {
 export function TaskOverview() {
   const navigate = useNavigate();
   const { data, isLoading } = useTasks({ pageSize: 100 });
+  const { token } = theme.useToken();
 
   const tasks = data?.tasks || [];
 
@@ -32,6 +30,10 @@ export function TaskOverview() {
     running: tasks.filter((t) => t.status === 'running' || t.status === 'retrying').length,
     completed: tasks.filter((t) => t.status === 'completed').length,
     error: tasks.filter((t) => t.status === 'error').length
+  };
+
+  const labelStyle: CSSProperties = {
+    color: token.colorTextSecondary
   };
 
   return (
@@ -47,19 +49,19 @@ export function TaskOverview() {
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>排队中</span>
-        <span style={{ ...valueStyle, color: '#faad14' }}>{stats.queued}</span>
+        <span style={{ ...valueStyle, color: token.colorWarning }}>{stats.queued}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>运行中</span>
-        <span style={{ ...valueStyle, color: '#1890ff' }}>{stats.running}</span>
+        <span style={{ ...valueStyle, color: token.colorPrimary }}>{stats.running}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>已完成</span>
-        <span style={{ ...valueStyle, color: '#52c41a' }}>{stats.completed}</span>
+        <span style={{ ...valueStyle, color: token.colorSuccess }}>{stats.completed}</span>
       </div>
       <div style={statStyle}>
         <span style={labelStyle}>错误</span>
-        <span style={{ ...valueStyle, color: '#ff4d4f' }}>{stats.error}</span>
+        <span style={{ ...valueStyle, color: token.colorError }}>{stats.error}</span>
       </div>
     </OverviewCard>
   );

--- a/packages/hr-agent-web/src/components/Layout/index.tsx
+++ b/packages/hr-agent-web/src/components/Layout/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Layout, Menu, Button, Avatar, Dropdown, Spin, Space } from 'antd';
+import { Layout, Menu, Button, Avatar, Dropdown, Spin, Space, theme } from 'antd';
 import {
   AppstoreOutlined,
   LogoutOutlined,
@@ -56,6 +56,7 @@ export function AppLayout({ children }: LayoutProps) {
   const location = useLocation();
   const { isAuthenticated, isLoading, logout } = useAuth();
   const { collapsed, toggleCollapsed } = useSiderCollapse();
+  const { token } = theme.useToken();
 
   if (isLoading) {
     return (
@@ -105,8 +106,8 @@ export function AppLayout({ children }: LayoutProps) {
         collapsed={collapsed}
         trigger={null}
       >
-        <div style={{ padding: '24px 20px', borderBottom: '1px solid #f0f0f0', display: 'flex', alignItems: 'center', gap: '12px' }}>
-          <RobotOutlined style={{ fontSize: '24px', color: '#1890ff' }} />
+        <div style={{ padding: '24px 20px', borderBottom: `1px solid ${token.colorBorder}`, display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <RobotOutlined style={{ fontSize: '24px', color: token.colorPrimary }} />
           {!collapsed && <h2 style={{ margin: 0, fontSize: '18px' }}>HR Agent</h2>}
         </div>
 
@@ -119,7 +120,7 @@ export function AppLayout({ children }: LayoutProps) {
           style={{ borderRight: 0 }}
         />
 
-        <div style={{ position: 'absolute', bottom: 0, width: '100%', padding: '16px', borderTop: '1px solid #f0f0f0' }}>
+        <div style={{ position: 'absolute', bottom: 0, width: '100%', padding: '16px', borderTop: `1px solid ${token.colorBorder}` }}>
           <Button
             type="text"
             onClick={toggleCollapsed}
@@ -130,7 +131,7 @@ export function AppLayout({ children }: LayoutProps) {
       </Sider>
 
       <Layout>
-        <Header style={{ background: '#fff', padding: '0 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <Header style={{ background: token.colorBgContainer, padding: '0 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <h1 style={{ margin: 0, fontSize: '20px' }}>{getPageTitle()}</h1>
           <Space size={16}>
             <ThemeSwitcher />
@@ -143,7 +144,7 @@ export function AppLayout({ children }: LayoutProps) {
           </Space>
         </Header>
 
-        <Content style={{ margin: '24px', padding: '24px', background: '#fff', minHeight: 'calc(100vh - 112px)' }}>
+        <Content style={{ margin: '24px', padding: '24px', background: token.colorBgContainer, minHeight: 'calc(100vh - 112px)' }}>
           {children}
         </Content>
       </Layout>

--- a/packages/hr-agent-web/src/components/ListHeader/index.tsx
+++ b/packages/hr-agent-web/src/components/ListHeader/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Button, Input, Space, Typography } from 'antd';
+import { Button, Input, Space, Typography, theme } from 'antd';
 import type { SearchProps } from 'antd/es/input/Search';
 
 const { Title } = Typography;
@@ -29,13 +29,15 @@ export function ListHeader({
   onSearch,
   actionButton
 }: ListHeaderProps) {
+  const { token } = theme.useToken();
+
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
         <Title level={2} style={{ margin: 0 }}>
           {title}
         </Title>
-        <span style={{ color: '#8c8c8c' }}>
+        <span style={{ color: token.colorTextSecondary }}>
           共 {count} {countLabel}
         </span>
       </div>

--- a/packages/hr-agent-web/src/components/StatsDashboard/index.tsx
+++ b/packages/hr-agent-web/src/components/StatsDashboard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Row, Col, Progress, Badge } from 'antd';
+import { Card, Row, Col, Progress, Badge, theme } from 'antd';
 import {
   FileTextOutlined,
   LoadingOutlined,
@@ -82,13 +82,15 @@ export function StatsDashboard({ tasks }: StatsDashboardProps) {
 }
 
 function TaskStatsCards({ stats, duration }: { stats: Record<string, number>; duration: number }) {
+  const { token } = theme.useToken();
+
   const cards = [
     {
       key: 'total',
       icon: <FileTextOutlined />,
       label: '总任务数',
       value: stats.total,
-      color: '#1890ff'
+      color: token.colorPrimary
     },
     {
       key: 'running',
@@ -96,21 +98,21 @@ function TaskStatsCards({ stats, duration }: { stats: Record<string, number>; du
       label: '进行中',
       value: stats.running,
       showPulse: stats.running > 0,
-      color: '#faad14'
+      color: token.colorWarning
     },
     {
       key: 'completed',
       icon: <CheckCircleOutlined />,
       label: '已完成',
       value: stats.completed,
-      color: '#52c41a'
+      color: token.colorSuccess
     },
     {
       key: 'error',
       icon: <ExclamationCircleOutlined />,
       label: '错误',
       value: stats.error,
-      color: '#ff4d4f'
+      color: token.colorError
     }
   ];
 
@@ -122,7 +124,7 @@ function TaskStatsCards({ stats, duration }: { stats: Record<string, number>; du
             <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
               <div style={{ fontSize: 32, color: card.color }}>{card.icon}</div>
               <div>
-                <div style={{ color: '#8c8c8c', fontSize: 14 }}>{card.label}</div>
+                <div style={{ color: token.colorTextSecondary, fontSize: 14 }}>{card.label}</div>
                 <div style={{ fontSize: 24, fontWeight: 600 }}>
                   <CountUp end={card.value} duration={duration} />
                 </div>
@@ -142,6 +144,8 @@ function CompletionRateCard({
   completionRate: number;
   strokeWidth: number;
 }) {
+  const { token } = theme.useToken();
+
   return (
     <Col xs={24} lg={8}>
       <Card>
@@ -151,7 +155,7 @@ function CompletionRateCard({
         </div>
         <Progress
           percent={completionRate}
-          strokeColor="#9333EA"
+          strokeColor={token.colorPrimary}
           strokeWidth={strokeWidth}
           showInfo={false}
         />
@@ -167,26 +171,28 @@ function AISystemCard({
   caStatus?: { total?: number; busy?: number; idle?: number };
   queuedCount: number;
 }) {
+  const { token } = theme.useToken();
+
   return (
     <Col xs={24} lg={8}>
       <Card>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-          <RobotOutlined style={{ fontSize: 20, color: '#9333EA' }} />
+          <RobotOutlined style={{ fontSize: 20, color: token.colorPrimary }} />
           <span style={{ fontWeight: 600 }}>AI 系统状态</span>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>活跃 Agent</span>
+            <span style={{ color: token.colorTextSecondary }}>活跃 Agent</span>
             <span>
               {caStatus?.busy ?? 0} / {caStatus?.total ?? 0}
             </span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>处理队列</span>
+            <span style={{ color: token.colorTextSecondary }}>处理队列</span>
             <span>{queuedCount} 个</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>空闲 Agent</span>
+            <span style={{ color: token.colorTextSecondary }}>空闲 Agent</span>
             <span>{caStatus?.idle ?? 0} 个</span>
           </div>
         </div>
@@ -204,18 +210,20 @@ function CAResourcePoolCard({
   caList: CADetail[];
   maxDisplay: number;
 }) {
+  const { token } = theme.useToken();
+
   const statusSummary = [
-    { label: '空闲', count: caStatus?.idle ?? 0, color: '#52c41a' },
-    { label: '忙碌', count: caStatus?.busy ?? 0, color: '#faad14' },
-    { label: '创建中', count: caStatus?.creating ?? 0, color: '#1890ff' },
-    { label: '错误', count: caStatus?.error ?? 0, color: '#ff4d4f' }
+    { label: '空闲', count: caStatus?.idle ?? 0, color: token.colorSuccess },
+    { label: '忙碌', count: caStatus?.busy ?? 0, color: token.colorWarning },
+    { label: '创建中', count: caStatus?.creating ?? 0, color: token.colorPrimary },
+    { label: '错误', count: caStatus?.error ?? 0, color: token.colorError }
   ];
 
   return (
     <Col xs={24} lg={8}>
       <Card>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-          <ApiOutlined style={{ fontSize: 20, color: '#9333EA' }} />
+          <ApiOutlined style={{ fontSize: 20, color: token.colorPrimary }} />
           <span style={{ fontWeight: 600 }}>CA 资源池</span>
         </div>
         <div>
@@ -226,7 +234,9 @@ function CAResourcePoolCard({
           </div>
           {caList.length > 0 && (
             <div>
-              <div style={{ color: '#8c8c8c', marginBottom: 8 }}>CA 列表 ({caList.length})</div>
+              <div style={{ color: token.colorTextSecondary, marginBottom: 8 }}>
+                CA 列表 ({caList.length})
+              </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {caList.slice(0, maxDisplay).map((ca: CADetail) => (
                   <div key={ca.id} style={{ display: 'flex', justifyContent: 'space-between' }}>
@@ -245,7 +255,9 @@ function CAResourcePoolCard({
                   </div>
                 ))}
                 {caList.length > maxDisplay && (
-                  <div style={{ color: '#8c8c8c' }}>+{caList.length - maxDisplay} 更多</div>
+                  <div style={{ color: token.colorTextSecondary }}>
+                    +{caList.length - maxDisplay} 更多
+                  </div>
                 )}
               </div>
             </div>
@@ -261,24 +273,26 @@ function IssueStatusCard({
 }: {
   issueStats: { total: number; inProgress: number; completed: number; deleted: number };
 }) {
+  const { token } = theme.useToken();
+
   return (
     <Col xs={24} lg={12}>
       <Card>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-          <IssueOutlined style={{ fontSize: 20, color: '#1890ff' }} />
+          <IssueOutlined style={{ fontSize: 20, color: token.colorPrimary }} />
           <span style={{ fontWeight: 600 }}>Issues 状态</span>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>进行中</span>
+            <span style={{ color: token.colorTextSecondary }}>进行中</span>
             <span>{issueStats.inProgress}</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>已完成</span>
+            <span style={{ color: token.colorTextSecondary }}>已完成</span>
             <span>{issueStats.completed}</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>已删除</span>
+            <span style={{ color: token.colorTextSecondary }}>已删除</span>
             <span>{issueStats.deleted}</span>
           </div>
         </div>
@@ -292,24 +306,26 @@ function PRStatusCard({
 }: {
   prStats: { total: number; inProgress: number; merged: number; deleted: number };
 }) {
+  const { token } = theme.useToken();
+
   return (
     <Col xs={24} lg={12}>
       <Card>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 16 }}>
-          <PROutlined style={{ fontSize: 20, color: '#52c41a' }} />
+          <PROutlined style={{ fontSize: 20, color: token.colorSuccess }} />
           <span style={{ fontWeight: 600 }}>PRs 状态</span>
         </div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>进行中</span>
+            <span style={{ color: token.colorTextSecondary }}>进行中</span>
             <span>{prStats.inProgress}</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>已合并</span>
+            <span style={{ color: token.colorTextSecondary }}>已合并</span>
             <span>{prStats.merged}</span>
           </div>
           <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-            <span style={{ color: '#8c8c8c' }}>已删除</span>
+            <span style={{ color: token.colorTextSecondary }}>已删除</span>
             <span>{prStats.deleted}</span>
           </div>
         </div>

--- a/packages/hr-agent-web/src/components/TaskCard/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskCard/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Tag, Button, Space, Progress } from 'antd';
+import { Card, Tag, Button, Space, Progress, theme } from 'antd';
 import {
   GithubOutlined,
   LinkOutlined,
@@ -78,11 +78,12 @@ function TaskCardContent({
   isRunning
 }: TaskCardContentProps) {
   const progress = getProgressByStatus(task);
+  const { token } = theme.useToken();
 
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-        <RobotOutlined style={{ color: '#9333EA' }} />
+        <RobotOutlined style={{ color: token.colorPrimary }} />
         <strong>{task.type}</strong>
       </div>
 
@@ -105,7 +106,7 @@ function TaskCardContent({
           <Progress
             percent={progress}
             size="small"
-            strokeColor="#9333EA"
+            strokeColor={token.colorPrimary}
             showInfo={false}
           />
         </div>
@@ -138,7 +139,7 @@ function TaskCardContent({
         )}
       </div>
 
-      <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: '#8c8c8c' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 4, color: token.colorTextSecondary }}>
         <ClockCircleOutlined />
         <small>{formatTimestamp(task.createdAt)}</small>
       </div>
@@ -147,6 +148,8 @@ function TaskCardContent({
 }
 
 export function TaskCard({ task, onClick, onEdit, onDelete, showActions = true }: TaskCardProps) {
+  const { token } = theme.useToken();
+
   const handleCAUrlClick = () => {
     if (task.codingAgent) {
       window.open(CA_BASE_URL, '_blank');
@@ -177,7 +180,7 @@ export function TaskCard({ task, onClick, onEdit, onDelete, showActions = true }
     <Card
       hoverable
       onClick={onClick}
-      style={isRunning ? { borderColor: '#faad14' } : undefined}
+      style={isRunning ? { borderColor: token.colorWarning } : undefined}
       title={
         <Space size={8}>
           <span>#{task.id}</span>

--- a/packages/hr-agent-web/src/components/TaskKanban/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskKanban/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Card, Col, Row, Button, Empty, Spin, message } from 'antd';
+import { Card, Col, Row, Button, Empty, Spin, message, theme } from 'antd';
 import { PlusOutlined, DownOutlined, LoadingOutlined } from '@ant-design/icons';
 import { DragDropContext, Droppable, Draggable, DropResult } from '@hello-pangea/dnd';
 import { TaskCard } from '../TaskCard';
@@ -99,6 +99,7 @@ function KanbanColumn({
   onEdit,
   onDelete
 }: KanbanColumnProps) {
+  const { token } = theme.useToken();
   const isDraggable = status === 'queued';
 
   return (
@@ -107,7 +108,7 @@ function KanbanColumn({
         title={
           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span>{title}</span>
-            <span style={{ color: '#8c8c8c', fontSize: 14 }}>
+            <span style={{ color: token.colorTextSecondary, fontSize: 14 }}>
               ({columnTasksList.length})
               {isReordering && isDraggable && <LoadingOutlined spin style={{ marginLeft: 8 }} />}
             </span>

--- a/packages/hr-agent-web/src/components/TaskModal/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskModal/index.tsx
@@ -1,4 +1,4 @@
-import { Modal, Descriptions, Tag, Tabs, Typography, Button } from 'antd';
+import { Modal, Descriptions, Tag, Tabs, Typography, Button, theme } from 'antd';
 import {
   GithubOutlined,
   LinkOutlined,
@@ -24,6 +24,8 @@ interface TaskModalProps {
 }
 
 export function TaskModal({ open, task, onClose }: TaskModalProps) {
+  const { token } = theme.useToken();
+
   if (!task) {
     return null;
   }
@@ -74,6 +76,21 @@ export function TaskModal({ open, task, onClose }: TaskModalProps) {
     </Descriptions>
   );
 
+  const emptyStateStyle = {
+    textAlign: 'center' as const,
+    padding: '40px 0'
+  };
+
+  const iconStyle = {
+    fontSize: 48,
+    color: token.colorTextDisabled
+  };
+
+  const textStyle = {
+    marginTop: 16,
+    color: token.colorTextSecondary
+  };
+
   const issueTab = task.issue ? (
     <Descriptions column={1} bordered>
       <Descriptions.Item label="Issue ID">#{task.issue.issueId}</Descriptions.Item>
@@ -90,9 +107,9 @@ export function TaskModal({ open, task, onClose }: TaskModalProps) {
       </Descriptions.Item>
     </Descriptions>
   ) : (
-    <div style={{ textAlign: 'center', padding: '40px 0' }}>
-      <CheckCircleOutlined style={{ fontSize: 48, color: '#d9d9d9' }} />
-      <p style={{ marginTop: 16, color: '#8c8c8c' }}>暂无关联的 Issue</p>
+    <div style={emptyStateStyle}>
+      <CheckCircleOutlined style={iconStyle} />
+      <p style={textStyle}>暂无关联的 Issue</p>
     </div>
   );
 
@@ -114,9 +131,9 @@ export function TaskModal({ open, task, onClose }: TaskModalProps) {
       </Descriptions.Item>
     </Descriptions>
   ) : (
-    <div style={{ textAlign: 'center', padding: '40px 0' }}>
-      <ClockCircleOutlined style={{ fontSize: 48, color: '#d9d9d9' }} />
-      <p style={{ marginTop: 16, color: '#8c8c8c' }}>暂无关联的 Pull Request</p>
+    <div style={emptyStateStyle}>
+      <ClockCircleOutlined style={iconStyle} />
+      <p style={textStyle}>暂无关联的 Pull Request</p>
     </div>
   );
 
@@ -142,9 +159,9 @@ export function TaskModal({ open, task, onClose }: TaskModalProps) {
       </Descriptions.Item>
     </Descriptions>
   ) : (
-    <div style={{ textAlign: 'center', padding: '40px 0' }}>
-      <ClockCircleOutlined style={{ fontSize: 48, color: '#d9d9d9' }} />
-      <p style={{ marginTop: 16, color: '#8c8c8c' }}>暂无关联的 Coding Agent</p>
+    <div style={emptyStateStyle}>
+      <ClockCircleOutlined style={iconStyle} />
+      <p style={textStyle}>暂无关联的 Coding Agent</p>
     </div>
   );
 

--- a/packages/hr-agent-web/src/components/TaskTable/index.tsx
+++ b/packages/hr-agent-web/src/components/TaskTable/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Spin, Tag, Table } from 'antd';
+import { Spin, Tag, Table, theme } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { useTasks } from '../../hooks/useTasks';
 import {
@@ -18,6 +18,7 @@ interface TaskTableProps {
 export function TaskTable({ params, onTaskClick }: TaskTableProps) {
   const { data, isLoading } = useTasks(params);
   const [tasks, setTasks] = useState<Task[]>([]);
+  const { token } = theme.useToken();
 
   useEffect(() => {
     if (data?.tasks) {
@@ -114,7 +115,7 @@ export function TaskTable({ params, onTaskClick }: TaskTableProps) {
         pagination={false}
       />
       {data?.pagination && (
-        <div style={{ marginTop: 16, color: '#8c8c8c' }}>
+        <div style={{ marginTop: 16, color: token.colorTextSecondary }}>
           共 {data.pagination.total} 条记录，第 {data.pagination.page} /{' '}
           {data.pagination.totalPages} 页
         </div>

--- a/packages/hr-agent-web/src/hooks/useAntdStyleToken.ts
+++ b/packages/hr-agent-web/src/hooks/useAntdStyleToken.ts
@@ -1,0 +1,36 @@
+import { theme } from 'antd';
+
+export function useAntdStyleToken() {
+  const { token } = theme.useToken();
+
+  return {
+    token,
+    colors: {
+      primary: token.colorPrimary,
+      success: token.colorSuccess,
+      warning: token.colorWarning,
+      error: token.colorError,
+      info: token.colorInfo,
+      text: token.colorText,
+      textSecondary: token.colorTextSecondary,
+      textTertiary: token.colorTextTertiary,
+      textDisabled: token.colorTextDisabled,
+      bgContainer: token.colorBgContainer,
+      bgLayout: token.colorBgLayout,
+      bgElevated: token.colorBgElevated,
+      border: token.colorBorder,
+      borderSecondary: token.colorBorderSecondary
+    },
+    spacing: {
+      xs: token.paddingXXS,
+      sm: token.paddingXS,
+      md: token.paddingSM,
+      lg: token.paddingMD,
+      xl: token.paddingLG,
+      xxl: token.paddingXL
+    },
+    borderRadius: token.borderRadius,
+    fontSize: token.fontSize,
+    fontFamily: token.fontFamily
+  };
+}

--- a/packages/hr-agent-web/src/pages/Cas/index.tsx
+++ b/packages/hr-agent-web/src/pages/Cas/index.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Card, Button, Table, Space, Empty, Input, Modal, Form, message, Tag, Drawer } from 'antd';
+import { Card, Button, Table, Space, Empty, Input, Modal, Form, message, Tag, Drawer, theme } from 'antd';
 import {
   PlusOutlined,
   EditOutlined,
@@ -135,6 +135,42 @@ const getCAColumns = (
     )
   }
 ];
+
+function CALogItem({ log }: { log: CodingAgentLog }) {
+  const { token } = theme.useToken();
+
+  return (
+    <div
+      style={{ padding: 16, border: `1px solid ${token.colorBorder}`, borderRadius: 8 }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: 12,
+          paddingBottom: 12,
+          borderBottom: `1px solid ${token.colorBorder}`
+        }}
+      >
+        <Tag>{log.action}</Tag>
+        <span style={{ fontSize: 12, color: token.colorTextTertiary }}>{formatDate(log.createdAt)}</span>
+      </div>
+      {log.oldValue && (
+        <div style={{ display: 'flex', gap: 8, marginBottom: 6, fontSize: 13 }}>
+          <span style={{ fontWeight: 500, color: token.colorTextSecondary }}>旧值:</span>
+          <span>{log.oldValue}</span>
+        </div>
+      )}
+      {log.newValue && (
+        <div style={{ display: 'flex', gap: 8, marginBottom: 6, fontSize: 13 }}>
+          <span style={{ fontWeight: 500, color: token.colorTextSecondary }}>新值:</span>
+          <span>{log.newValue}</span>
+        </div>
+      )}
+    </div>
+  );
+}
 
 // eslint-disable-next-line max-lines-per-function
 function CAsListContent({
@@ -362,36 +398,7 @@ function CAsListContent({
           {selectedCA?.logs && selectedCA.logs.length > 0 ? (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
               {selectedCA.logs.map((log: CodingAgentLog) => (
-                <div
-                  key={log.id}
-                  style={{ padding: 16, border: '1px solid #f0f0f0', borderRadius: 8 }}
-                >
-                  <div
-                    style={{
-                      display: 'flex',
-                      justifyContent: 'space-between',
-                      alignItems: 'center',
-                      marginBottom: 12,
-                      paddingBottom: 12,
-                      borderBottom: '1px solid #f0f0f0'
-                    }}
-                  >
-                    <Tag>{log.action}</Tag>
-                    <span style={{ fontSize: 12, color: '#999' }}>{formatDate(log.createdAt)}</span>
-                  </div>
-                  {log.oldValue && (
-                    <div style={{ display: 'flex', gap: 8, marginBottom: 6, fontSize: 13 }}>
-                      <span style={{ fontWeight: 500, color: '#666' }}>旧值:</span>
-                      <span>{log.oldValue}</span>
-                    </div>
-                  )}
-                  {log.newValue && (
-                    <div style={{ display: 'flex', gap: 8, marginBottom: 6, fontSize: 13 }}>
-                      <span style={{ fontWeight: 500, color: '#666' }}>新值:</span>
-                      <span>{log.newValue}</span>
-                    </div>
-                  )}
-                </div>
+                <CALogItem key={log.id} log={log} />
               ))}
             </div>
           ) : (

--- a/packages/hr-agent-web/src/pages/IssueDetail/index.tsx
+++ b/packages/hr-agent-web/src/pages/IssueDetail/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Button, Descriptions, Space, Empty, message, Modal } from 'antd';
+import { Card, Button, Descriptions, Space, Empty, message, Modal, theme } from 'antd';
 import { ArrowLeftOutlined, EditOutlined, LinkOutlined, DeleteOutlined } from '@ant-design/icons';
 import { useIssue, useDeleteIssue } from '../../hooks/useIssues';
 import { formatDate, getIssueStatusTag } from '../../utils/formatters';
@@ -10,6 +10,7 @@ export function IssueDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const { token } = theme.useToken();
 
   const { data, isLoading } = useIssue(parseInt(id || '0', 10));
   const deleteIssue = useDeleteIssue();
@@ -52,7 +53,7 @@ export function IssueDetail() {
           </div>
 
           <Card>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 28, paddingBottom: 20, borderBottom: '1px solid #f0f0f0' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 28, paddingBottom: 20, borderBottom: `1px solid ${token.colorBorder}` }}>
               <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600 }}>
                 <span style={{ fontFamily: 'monospace' }}>#{issue.issueId}</span> {issue.issueTitle}
               </h1>
@@ -82,13 +83,13 @@ export function IssueDetail() {
             </Descriptions>
 
             {issue.issueContent && (
-              <div style={{ marginTop: 28, paddingTop: 24, borderTop: '1px solid #f0f0f0' }}>
+              <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${token.colorBorder}` }}>
                 <h3 style={{ margin: '0 0 16px 0', fontSize: 16, fontWeight: 600 }}>内容</h3>
                 <div
                   style={{
                     padding: 20,
-                    background: '#fafafa',
-                    border: '1px solid #f0f0f0',
+                    background: token.colorBgLayout,
+                    border: `1px solid ${token.colorBorder}`,
                     borderRadius: 8,
                     lineHeight: 1.7,
                     whiteSpace: 'pre-wrap',

--- a/packages/hr-agent-web/src/pages/Login/index.tsx
+++ b/packages/hr-agent-web/src/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Form, Input, Button, Typography, Space, message } from 'antd';
+import { Form, Input, Button, Typography, Space, message, theme } from 'antd';
 import { LockOutlined, RobotOutlined, ApiOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../hooks/useAuth';
@@ -11,10 +11,21 @@ interface LoginForm {
   secret: string;
 }
 
+const HEX_RADIX = 16;
+const COLOR_START_INDEX = 1;
+const COLOR_R_INDEX_END = 3;
+const COLOR_G_INDEX_START = 3;
+const COLOR_G_INDEX_END = 5;
+const COLOR_B_INDEX_START = 5;
+const COLOR_B_INDEX_END = 7;
+const OPACITY_10 = 0.1;
+const OPACITY_25 = 0.25;
+
 export function Login() {
   const navigate = useNavigate();
   const { login, isAuthenticated } = useAuth();
   const [loading, setLoading] = useState(false);
+  const { token } = theme.useToken();
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -40,6 +51,9 @@ export function Login() {
     }
   };
 
+  const primaryColorRgba10 = `rgba(${parseInt(token.colorPrimary.slice(COLOR_START_INDEX, COLOR_R_INDEX_END), HEX_RADIX)}, ${parseInt(token.colorPrimary.slice(COLOR_G_INDEX_START, COLOR_G_INDEX_END), HEX_RADIX)}, ${parseInt(token.colorPrimary.slice(COLOR_B_INDEX_START, COLOR_B_INDEX_END), HEX_RADIX)}, ${OPACITY_10})`;
+  const primaryColorRgba25 = `rgba(${parseInt(token.colorPrimary.slice(COLOR_START_INDEX, COLOR_R_INDEX_END), HEX_RADIX)}, ${parseInt(token.colorPrimary.slice(COLOR_G_INDEX_START, COLOR_G_INDEX_END), HEX_RADIX)}, ${parseInt(token.colorPrimary.slice(COLOR_B_INDEX_START, COLOR_B_INDEX_END), HEX_RADIX)}, ${OPACITY_25})`;
+
   return (
     <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 20 }}>
       <div style={{ position: 'relative', zIndex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', width: '100%', maxWidth: 450 }}>
@@ -56,9 +70,9 @@ export function Login() {
                 alignItems: 'center',
                 justifyContent: 'center',
                 fontSize: 48,
-                background: 'rgba(139, 92, 246, 0.1)',
+                background: primaryColorRgba10,
                 borderRadius: '50%',
-                border: '2px solid rgba(139, 92, 246, 0.25)'
+                border: `2px solid ${primaryColorRgba25}`
               }}
             >
               <RobotOutlined />
@@ -66,13 +80,13 @@ export function Login() {
             <Title level={2} style={{ margin: 0, fontSize: 36, fontWeight: 700 }}>
               HR Agent
             </Title>
-            <Text style={{ color: '#8b5cf6', fontSize: 13, fontWeight: 500, letterSpacing: 1, textTransform: 'uppercase' }}>
+            <Text style={{ color: token.colorPrimary, fontSize: 13, fontWeight: 500, letterSpacing: 1, textTransform: 'uppercase' }}>
               AI-Powered Task Orchestration Platform
             </Text>
             <Text style={{ fontSize: 16 }}>智能任务编排平台</Text>
           </div>
 
-          <div style={{ width: '100%', padding: 40, border: '1px solid #f0f0f0', borderRadius: 24 }}>
+          <div style={{ width: '100%', padding: 40, border: `1px solid ${token.colorBorder}`, borderRadius: 24 }}>
             <Space direction="vertical" size="large" style={{ width: '100%' }}>
               <div>
                 <Title level={4} style={{ margin: '0 0 8px' }}>
@@ -97,7 +111,7 @@ export function Login() {
                 </Form.Item>
               </Form>
 
-              <div style={{ textAlign: 'center', paddingTop: 24, borderTop: '1px solid #f0f0f0' }}>
+              <div style={{ textAlign: 'center', paddingTop: 24, borderTop: `1px solid ${token.colorBorder}` }}>
                 <Space>
                   <ApiOutlined />
                   <Text type="secondary" style={{ fontSize: 13 }}>

--- a/packages/hr-agent-web/src/pages/PrDetail/index.tsx
+++ b/packages/hr-agent-web/src/pages/PrDetail/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Card, Button, Descriptions, Space, Empty, Modal, message } from 'antd';
+import { Card, Button, Descriptions, Space, Empty, Modal, message, theme } from 'antd';
 import { ArrowLeftOutlined, EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import { usePR, useDeletePR } from '../../hooks/usePrs';
 import { formatDate, getPRStatusTag } from '../../utils/formatters';
@@ -10,6 +10,7 @@ export function PRDetail() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const { token } = theme.useToken();
 
   const { data, isLoading } = usePR(parseInt(id || '0', 10));
   const deletePR = useDeletePR();
@@ -49,7 +50,7 @@ export function PRDetail() {
           </div>
 
           <Card>
-            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 28, paddingBottom: 20, borderBottom: '1px solid #f0f0f0' }}>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 28, paddingBottom: 20, borderBottom: `1px solid ${token.colorBorder}` }}>
               <h1 style={{ margin: 0, fontSize: 26, fontWeight: 600 }}>
                 <span style={{ fontFamily: 'monospace' }}>#{pr.prId}</span> {pr.prTitle}
               </h1>
@@ -75,13 +76,13 @@ export function PRDetail() {
             </Descriptions>
 
             {pr.prContent && (
-              <div style={{ marginTop: 28, paddingTop: 24, borderTop: '1px solid #f0f0f0' }}>
+              <div style={{ marginTop: 28, paddingTop: 24, borderTop: `1px solid ${token.colorBorder}` }}>
                 <h3 style={{ margin: '0 0 16px 0', fontSize: 16, fontWeight: 600 }}>内容</h3>
                 <div
                   style={{
                     padding: 20,
-                    background: '#fafafa',
-                    border: '1px solid #f0f0f0',
+                    background: token.colorBgLayout,
+                    border: `1px solid ${token.colorBorder}`,
                     borderRadius: 8,
                     lineHeight: 1.7,
                     whiteSpace: 'pre-wrap',

--- a/packages/hr-agent-web/src/pages/TaskList/columns.tsx
+++ b/packages/hr-agent-web/src/pages/TaskList/columns.tsx
@@ -28,31 +28,6 @@ import { CA_BASE_URL } from '../../utils/constants';
 
 const RUNNING_STATUSES = ['running', 'retrying', 'in_development'];
 const ERROR_STATUSES = ['error', 'timeout'];
-const COLOR_BLUE = '#3b82f6';
-const COLOR_GREEN = '#10b981';
-const COLOR_RED = '#ef4444';
-const COLOR_GRAY = '#6b7280';
-const COLOR_PURPLE = '#9333EA';
-
-const getStatusIcon = (status: TaskStatus) => {
-  switch (status) {
-    case 'running':
-    case 'retrying':
-    case 'creating_ca':
-    case 'connecting_ca':
-    case 'ai_coding':
-    case 'creating_pr':
-      return <LoadingOutlined spin style={{ color: COLOR_BLUE }} />;
-    case 'completed':
-    case 'pr_submitted':
-      return <CheckCircleOutlined style={{ color: COLOR_GREEN }} />;
-    case 'error':
-    case 'timeout':
-      return <ExclamationCircleOutlined style={{ color: COLOR_RED }} />;
-    default:
-      return <ClockCircleOutlined style={{ color: COLOR_GRAY }} />;
-  }
-};
 
 const getProgressByStatus = (status: TaskStatus): number => {
   const progressMap: Record<TaskStatus, number> = {
@@ -165,7 +140,7 @@ export const getTaskListColumns = (onNavigate: (path: string) => void): ColumnsT
     width: 140,
     render: (status: TaskStatus) => (
       <Space size={4}>
-        {getStatusIcon(status)}
+        <StatusIcon status={status} />
         <Tag color={TASK_STATUS_COLORS[status]} className="task-list-status-tag">
           {TASK_STATUS_LABELS[status]}
         </Tag>
@@ -177,22 +152,7 @@ export const getTaskListColumns = (onNavigate: (path: string) => void): ColumnsT
     title: '进度',
     key: 'progress',
     width: 150,
-    render: (_: unknown, record: Task) => {
-      const progress = getProgressByStatus(record.status);
-      const isRunning = isRunningStatus(record.status);
-      return (
-        <div className="task-list-progress">
-          <Progress
-            percent={progress}
-            size="small"
-            strokeColor={isRunning ? COLOR_BLUE : COLOR_PURPLE}
-            showInfo={false}
-            className={isRunning ? 'progress-animated' : ''}
-          />
-          <span className="progress-text">{progress}%</span>
-        </div>
-      );
-    }
+    render: (_: unknown, record: Task) => <ProgressColumn record={record} />
   },
   {
     title: '类型',
@@ -262,6 +222,45 @@ export const getTaskListColumns = (onNavigate: (path: string) => void): ColumnsT
     sorter: (a: Task, b: Task) => a.updatedAt - b.updatedAt
   }
 ];
+
+function StatusIcon({ status }: { status: TaskStatus }) {
+  switch (status) {
+    case 'running':
+    case 'retrying':
+    case 'creating_ca':
+    case 'connecting_ca':
+    case 'ai_coding':
+    case 'creating_pr':
+      return <LoadingOutlined spin style={{ color: 'var(--ant-color-primary)' }} />;
+    case 'completed':
+    case 'pr_submitted':
+      return <CheckCircleOutlined style={{ color: 'var(--ant-color-success)' }} />;
+    case 'error':
+    case 'timeout':
+      return <ExclamationCircleOutlined style={{ color: 'var(--ant-color-error)' }} />;
+    default:
+      return <ClockCircleOutlined style={{ color: 'var(--ant-color-text-secondary)' }} />;
+  }
+}
+
+function ProgressColumn({ record }: { record: Task }) {
+  const progress = getProgressByStatus(record.status);
+  const isRunning = isRunningStatus(record.status);
+  const strokeColor = isRunning ? 'var(--ant-color-primary)' : 'var(--ant-color-primary)';
+
+  return (
+    <div className="task-list-progress">
+      <Progress
+        percent={progress}
+        size="small"
+        strokeColor={strokeColor}
+        showInfo={false}
+        className={isRunning ? 'progress-animated' : ''}
+      />
+      <span className="progress-text">{progress}%</span>
+    </div>
+  );
+}
 
 export const calculateStatusCounts = (tasks: Task[]) => {
   const counts = {


### PR DESCRIPTION
## Changes
- [x] Refactored components to use Ant Design theme tokens
  - [x] Updated pages to use token-based styling
  - [x] Ensured proper dark mode support
  - [x] All tests pass

## Test Coverage
- Verified components render correctly with Ant Design CSS variables
- [x] Added useAntdStyleToken hook for convenient token access

## Notes
- TaskModal function exceeds 150 lines (existing issue, please review if simplification is needed